### PR TITLE
feat: add endpoint to list top highlights for the date range

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -188,7 +188,7 @@ module.exports = {
     "newline-per-chained-call": [
       "error",
       {
-        ignoreChainWithDepth: 2,
+        ignoreChainWithDepth: 3,
       },
     ],
     "no-multi-spaces": "error",

--- a/src/highlight/highlight.controller.ts
+++ b/src/highlight/highlight.controller.ts
@@ -102,4 +102,15 @@ export class HighlightController {
   async getAllHighlightReactions(@Param("id", ParseIntPipe) id: number): Promise<DbUserHighlightReactionResponse[]> {
     return this.userHighlightsService.findAllHighlightReactions(id);
   }
+
+  @Get("/top")
+  @ApiOperation({
+    operationId: "findTopHighlights",
+    summary: "Finds top highlights for the day range and paginates them",
+  })
+  @ApiPaginatedResponse(DbUserHighlight)
+  @ApiOkResponse({ type: DbUserHighlight })
+  async findTopHighlights(@Query() pageOptionsDto: PageOptionsDto): Promise<PageDto<DbUserHighlight>> {
+    return this.userHighlightsService.findTop(pageOptionsDto);
+  }
 }


### PR DESCRIPTION
## Description

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->
Adds and endpoint to list top highlights for the given day range (7 days) be default

## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents
<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 
-->

https://github.com/open-sauced/ops-backend/issues/87

## Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->

![image](https://github.com/open-sauced/api/assets/42211/04e0d6a3-1d3e-449a-aa8a-a5ad90efdb37)

Sample output

```json
{
  "data": [
    {
      "id": 169,
      "user_id": 47471007,
      "url": "https://github.com/open-sauced/ai/pull/211",
      "title": "feat: make formal the default tone",
      "highlight": "test",
      "type": "pull_request",
      "pinned": false,
      "featured": false,
      "created_at": "2023-07-31T17:11:22.330Z",
      "updated_at": "2023-07-31T17:11:22.330Z",
      "deleted_at": null,
      "shipped_at": "2023-07-31T22:11:22.277Z"
    },
    {
      "id": 170,
      "user_id": 42211,
      "url": "https://github.com/brandonroberts/blog/pull/39",
      "title": "Test unknown repo from highlight",
      "highlight": "I wrote a blog post",
      "type": "pull_request",
      "pinned": false,
      "featured": false,
      "created_at": "2023-08-01T19:15:32.197Z",
      "updated_at": "2023-08-01T19:15:32.197Z",
      "deleted_at": null,
      "shipped_at": "2023-08-02T00:15:32.158Z"
    },
    {
      "id": 171,
      "user_id": 47471007,
      "url": "https://github.com/open-sauced/ai/pull/211",
      "title": "feat: make formal the default tone",
      "highlight": "Update `getDefaultDescriptionConfig` in `descriptionconfig.ts` to set the tone to \"formal\" instead of \"informative\". This change ensures that the generated descriptions for AI models have a formal tone.",
      "type": "pull_request",
      "pinned": false,
      "featured": false,
      "created_at": "2023-08-02T18:08:48.822Z",
      "updated_at": "2023-08-02T18:08:48.822Z",
      "deleted_at": null,
      "shipped_at": "2023-08-02T23:08:48.772Z"
    }
  ],
  "meta": {
    "page": 1,
    "limit": 10,
    "itemCount": 3,
    "pageCount": 1,
    "hasPreviousPage": false,
    "hasNextPage": false
  }
}
```

## Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 docs.opensauced.pizza
- [ ] 🍕 dev.to/opensauced
- [ ] 📕 storybook
- [ ] 🙅 no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?



## [optional] What gif best describes this PR or how it makes you feel?



<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
