### PR TITLE
feat: add endpoints for churned and repeat contributors

### DIFF
--- a/src/contributor/contributor-insights.controller.ts
+++ b/src/contributor/contributor-insights.controller.ts
@@ -38,4 +38,30 @@ export class ContributorInsightsController {
   ): Promise<PageDto<DbPullRequestContributor>> {
     return this.pullRequestService.findAllRecentContributors(pageOptionsDto);
   }
+
+  @Get("/churn")
+  @ApiOperation({
+    operationId: "findAllChurnPullRequestContributors",
+    summary: "Gets all recent churned contributors for the last 30 days based on repo IDs",
+  })
+  @ApiPaginatedResponse(DbPullRequestContributor)
+  @ApiOkResponse({ type: DbPullRequestContributor })
+  async findAllChurnPullRequestContributors(
+    @Query() pageOptionsDto: PullRequestContributorInsightsDto
+  ): Promise<PageDto<DbPullRequestContributor>> {
+    return this.pullRequestService.findAllChurnContributors(pageOptionsDto);
+  }
+
+  @Get("/repeat")
+  @ApiOperation({
+    operationId: "findAllRepeatPullRequestContributors",
+    summary: "Gets all recent repeat contributors for the last 30 days based on repo IDs",
+  })
+  @ApiPaginatedResponse(DbPullRequestContributor)
+  @ApiOkResponse({ type: DbPullRequestContributor })
+  async findAllRepeatPullRequestContributors(
+    @Query() pageOptionsDto: PullRequestContributorInsightsDto
+  ): Promise<PageDto<DbPullRequestContributor>> {
+    return this.pullRequestService.findAllRepeatContributors(pageOptionsDto);
+  }
 }


### PR DESCRIPTION
## Description

- Adds endpoints for repeat and churned contributors for the provided repo IDs.
- Also fixes a bug for the contributor insights for new contributors

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

Related to https://github.com/open-sauced/ops-backend/issues/6

## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents
<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 
-->

## Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->

![image](https://github.com/open-sauced/api/assets/42211/661b5162-302b-4b49-8cc8-32535457a77a)


Churn contributors for `open-sauced/insights` based on development data

```json
{
  "data": [
    {
      "author_login": "ThePromiseBenard"
    }
  ],
  "meta": {
    "page": 1,
    "limit": 10,
    "itemCount": 1,
    "pageCount": 1,
    "hasPreviousPage": false,
    "hasNextPage": false
  }
}
```

Repeat contributors for `open-sauced/insights` based on development data


```json
{
  "data": [
    {
      "author_login": "babblebey"
    },
    {
      "author_login": "brandonroberts"
    },
    {
      "author_login": "foxyblocks"
    },
    {
      "author_login": "Lucif3r-in"
    },
    {
      "author_login": "OgDev-01"
    }
  ],
  "meta": {
    "page": 1,
    "limit": 10,
    "itemCount": 5,
    "pageCount": 1,
    "hasPreviousPage": false,
    "hasNextPage": false
  }
}
```


## Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 docs.opensauced.pizza
- [ ] 🍕 dev.to/opensauced
- [ ] 📕 storybook
- [ ] 🙅 no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?



## [optional] What gif best describes this PR or how it makes you feel?

<img src="https://media3.giphy.com/media/fRhSHzQ4NXOdrHIZJd/giphy.gif"/>

<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
