### PR TITLE
fix: update BakeRepoDto.wait to boolean

### DIFF
--- a/src/pizza/dtos/baked-repo.dto.ts
+++ b/src/pizza/dtos/baked-repo.dto.ts
@@ -12,7 +12,7 @@ export class BakeRepoDto {
 
   @ApiProperty({
     description: "Option to wait for Pizza service to finish baking repo",
-    type: String,
+    type: Boolean,
     example: false,
   })
   @IsBoolean()

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -6043,7 +6043,7 @@ components:
           description: Repo clone URL
           example: https://github.com/open-sauced/insights
         wait:
-          type: string
+          type: boolean
           description: Option to wait for Pizza service to finish baking repo
           example: false
       required:


### PR DESCRIPTION
## Description

API calls to [POST /v1/bake](https://api.opensauced.pizza/#/Pizza%20oven%20service/Bake%20a%20repository%20with%20the%20pizza%20oven%20microservice) fail with status code 400 because the expected type in the pizza service is boolean.

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents
Relates to https://github.com/open-sauced/go-api/issues/2

## Steps to reproduce

1. Go to https://api.opensauced.pizza/#/Pizza%20oven%20service/Bake%20a%20repository%20with%20the%20pizza%20oven%20microservice
2. Set environment to production
3. Set the request body to:
```
{
  "url": "https://github.com/open-sauced/insights",
  "wait": "false"
}
```
4. Observe the response status code to be 400
5. Set the request body to:
```
{
  "url": "https://github.com/open-sauced/insights",
  "wait": false
}
```
6. Observe the response status code to be 201

## Mobile & Desktop Screenshots/Recordings

N/A


## Added tests?

- [ ] 👍 yes
- [X] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 docs.opensauced.pizza
- [ ] 🍕 dev.to/opensauced
- [ ] 📕 storybook
- [X] 🙅 no documentation needed

## Are there any post-deployment tasks we need to perform?
Update / regenerate the [open-sauced/go-api](https://github.com/open-sauced/go-api) client.