### PR TITLE
fix: Highlight users string type in array for swagger

### DIFF
--- a/src/highlight/dtos/highlight-options.dto.ts
+++ b/src/highlight/dtos/highlight-options.dto.ts
@@ -16,6 +16,7 @@ export class HighlightOptionsDto extends PageOptionsDto {
 export class DbUserHighlightReactionResponse extends PickType(DbUserHighlightReaction, ["emoji_id", "reaction_count"]) {
   @ApiPropertyOptional({
     description: "Usernames of users who reacted with this emoji",
+    type: "string",
     example: ["RitaDee", "diivi"],
     isArray: true,
   })

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -5073,8 +5073,6 @@ components:
           type: string
           description: Top User Login
           example: bdougie
-      required:
-        - login
     CreateUserHighlightDto:
       type: object
       properties:
@@ -5158,19 +5156,15 @@ components:
         reaction_count:
           type: integer
         reaction_users:
+          description: Usernames of users who reacted with this emoji
+          example:
+            - RitaDee
+            - diivi
           type: array
           items:
-            required: false
-            description: Usernames of users who reacted with this emoji
-            example:
-              - RitaDee
-              - diivi
-            type: array
-            items:
-              type: string
+            type: string
       required:
         - emoji_id
-        - reaction_users
     DbUserHighlightReaction:
       type: object
       properties:
@@ -5214,8 +5208,6 @@ components:
           type: string
           description: Highlight Repo Full Name
           example: open-sauced/insights
-      required:
-        - full_name
     DbUserToUserFollows:
       type: object
       properties:
@@ -6039,7 +6031,6 @@ components:
           example: 2022-08-28 22:04:29.000000
       required:
         - author_login
-        - updated_at
     BakeRepoDto:
       type: object
       properties:


### PR DESCRIPTION
## Description

The highlights usernames that are returned in the array are of type "string" for the individual items for the swagger doc.

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

N/a - related to ongoing swagger Go API client generation shenanigans.

## Mobile & Desktop Screenshots/Recordings

N/a

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 docs.opensauced.pizza
- [ ] 🍕 dev.to/opensauced
- [ ] 📕 storybook
- [x] 🙅 no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?



## [optional] What gif best describes this PR or how it makes you feel?



<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
