### PR TITLE
feat: Dynamic API timeblocks for queries with ranges

### DIFF
--- a/src/common/dtos/page-options.dto.ts
+++ b/src/common/dtos/page-options.dto.ts
@@ -45,6 +45,17 @@ export class PageOptionsDto {
   @IsOptional()
   readonly range?: number = 30;
 
+  @ApiPropertyOptional({
+    description: "Number of days in the past to start range block",
+    default: 0,
+    type: "integer",
+  })
+  @Type(() => Number)
+  @IsIn([0, 7, 30, 90])
+  @IsInt()
+  @IsOptional()
+  readonly prev_days_start_date?: number = 0;
+
   get skip(): number {
     return ((this.page ?? 1) - 1) * (this.limit ?? 50);
   }

--- a/src/common/filters/repo-filter.service.ts
+++ b/src/common/filters/repo-filter.service.ts
@@ -12,7 +12,7 @@ export class RepoFilterService {
    * @param range
    */
 
-  getRepoFilters(options: FilterOptionsDto, range = 0): [string, object][] {
+  getRepoFilters(options: FilterOptionsDto, startDate = "NOW()", range = 0): [string, object][] {
     const filters: [string, object][] = [];
 
     if (options.repoIds) {
@@ -51,7 +51,8 @@ export class RepoFilterService {
           FROM "pull_requests" "spam_pull_requests"
           WHERE
             'spam' = ANY("spam_pull_requests"."label_names")
-            AND now() - INTERVAL '${range} days' <= "spam_pull_requests"."updated_at"
+            AND '${startDate}'::DATE >= "spam_pull_requests"."updated_at"
+            AND '${startDate}'::DATE - INTERVAL '${range} days' <= "spam_pull_requests"."updated_at"
         )
       `,
         {},

--- a/src/common/util/datetimes.ts
+++ b/src/common/util/datetimes.ts
@@ -1,0 +1,3 @@
+// converts the number of previous days into milliseconds and back to a date iso string
+export const GetPrevDateISOString = (prev_start_date = 0): string =>
+  new Date(Date.now() - prev_start_date * 24 * 60 * 60 * 1000).toISOString();

--- a/src/repo/repo.service.ts
+++ b/src/repo/repo.service.ts
@@ -9,6 +9,7 @@ import { OrderDirectionEnum } from "../common/constants/order-direction.constant
 import { InsightFilterFieldsEnum } from "../insight/dtos/insight-options.dto";
 import { RepoFilterService } from "../common/filters/repo-filter.service";
 import { PageOptionsDto } from "../common/dtos/page-options.dto";
+import { GetPrevDateISOString } from "../common/util/datetimes";
 import { RepoOrderFieldsEnum, RepoPageOptionsDto } from "./dtos/repo-page-options.dto";
 import { DbRepo } from "./entities/repo.entity";
 import { RepoSearchOptionsDto } from "./dtos/repo-search-options.dto";
@@ -62,7 +63,7 @@ export class RepoService {
     return builder;
   }
 
-  private baseFilterQueryBuilder(range = 30) {
+  private baseFilterQueryBuilder(startDate = "NOW()", range = 30) {
     return this.repoRepository
       .createQueryBuilder("repos")
       .addSelect(
@@ -72,7 +73,8 @@ export class RepoService {
           WHERE
             LOWER("open_pull_requests"."state") = 'open'
             AND "open_pull_requests"."repo_id" = "repos"."id"
-            AND now() - INTERVAL '${range} days' <= "open_pull_requests"."updated_at"
+            AND '${startDate}'::DATE >= "open_pull_requests"."updated_at"
+            AND '${startDate}'::DATE - INTERVAL '${range} days' <= "open_pull_requests"."updated_at"
         )::INTEGER`,
         "repos_open_prs_count"
       )
@@ -84,7 +86,8 @@ export class RepoService {
             LOWER("closed_pull_requests"."state") = 'closed'
             AND "closed_pull_requests"."merged" = false
             AND "closed_pull_requests"."repo_id" = "repos"."id"
-            AND now() - INTERVAL '${range} days' <= "closed_pull_requests"."updated_at"
+            AND '${startDate}'::DATE >= "closed_pull_requests"."updated_at"
+            AND '${startDate}'::DATE - INTERVAL '${range} days' <= "closed_pull_requests"."updated_at"
         )::INTEGER`,
         `repos_closed_prs_count`
       )
@@ -96,7 +99,8 @@ export class RepoService {
             (LOWER("merged_pull_requests"."state") = 'merged'
             OR "merged_pull_requests"."merged" = true)
             AND "merged_pull_requests"."repo_id" = "repos"."id"
-            AND now() - INTERVAL '${range} days' <= "merged_pull_requests"."updated_at"
+            AND '${startDate}'::DATE >= "merged_pull_requests"."updated_at"
+            AND '${startDate}'::DATE - INTERVAL '${range} days' <= "merged_pull_requests"."updated_at"
         )::INTEGER`,
         `repos_merged_prs_count`
       )
@@ -107,7 +111,8 @@ export class RepoService {
           WHERE
             "draft_pull_requests"."draft" = true
             AND "draft_pull_requests"."repo_id" = "repos"."id"
-            AND now() - INTERVAL '${range} days' <= "draft_pull_requests"."updated_at"
+            AND '${startDate}'::DATE >= "draft_pull_requests"."updated_at"
+            AND '${startDate}'::DATE - INTERVAL '${range} days' <= "draft_pull_requests"."updated_at"
         )::INTEGER`,
         `repos_draft_prs_count`
       )
@@ -118,7 +123,8 @@ export class RepoService {
           WHERE
             'spam' = ANY("spam_pull_requests"."label_names")
             AND "spam_pull_requests"."repo_id" = "repos"."id"
-            AND now() - INTERVAL '${range} days' <= "spam_pull_requests"."updated_at"
+            AND '${startDate}'::DATE >= "spam_pull_requests"."updated_at"
+            AND '${startDate}'::DATE - INTERVAL '${range} days' <= "spam_pull_requests"."updated_at"
         )::INTEGER`,
         `repos_spam_prs_count`
       )
@@ -129,7 +135,8 @@ export class RepoService {
           WHERE
             "pull_requests_velocity"."repo_id" = "repos"."id"
             AND "pull_requests_velocity"."closed_at" > "pull_requests_velocity"."created_at"
-            AND now() - INTERVAL '${range} days' <= "pull_requests_velocity"."updated_at"
+            AND '${startDate}'::DATE >= "pull_requests_velocity"."updated_at"
+            AND '${startDate}'::DATE - INTERVAL '${range} days' <= "pull_requests_velocity"."updated_at"
         )::INTEGER`,
         `repos_pr_velocity_count`
       )
@@ -139,7 +146,8 @@ export class RepoService {
           FROM "pull_requests" "active_pull_requests"
           WHERE
             "active_pull_requests"."repo_id" = "repos"."id"
-            AND now() - INTERVAL '${range} days' <= "active_pull_requests"."updated_at"
+            AND '${startDate}'::DATE >= "active_pull_requests"."updated_at"
+            AND '${startDate}'::DATE - INTERVAL '${range} days' <= "active_pull_requests"."updated_at"
             AND "active_pull_requests".state != 'closed'
         )::INTEGER`,
         `repo_active_prs_count`
@@ -338,6 +346,7 @@ export class RepoService {
 
   async findAllWithFilters(pageOptionsDto: RepoSearchOptionsDto): Promise<PageDto<DbRepo>> {
     const orderField = pageOptionsDto.orderBy ?? "stars";
+    const startDate = GetPrevDateISOString(pageOptionsDto.prev_days_start_date);
     const range = pageOptionsDto.range!;
 
     let queryBuilder;
@@ -347,14 +356,15 @@ export class RepoService {
         queryBuilder = this.hacktoberfestfilterquerybuilder(range);
         break;
       default:
-        queryBuilder = this.baseFilterQueryBuilder(range);
+        queryBuilder = this.baseFilterQueryBuilder(startDate, range);
         break;
     }
 
-    const filters = this.filterService.getRepoFilters(pageOptionsDto, range);
+    const filters = this.filterService.getRepoFilters(pageOptionsDto, startDate, range);
 
     if (!pageOptionsDto.repoIds && !pageOptionsDto.repo) {
-      filters.push([`now() - INTERVAL '${range} days' <= "repos"."updated_at"`, { range }]);
+      filters.push([`'${startDate}'::DATE >= "repos"."updated_at"`, { range }]);
+      filters.push([`'${startDate}'::DATE - INTERVAL '${range} days' <= "repos"."updated_at"`, { range }]);
     }
 
     this.filterService.applyQueryBuilderFilters(queryBuilder, filters);
@@ -370,16 +380,17 @@ export class RepoService {
         countQueryBuilder = this.hacktoberfestfilterquerybuilder(range);
         break;
       default:
-        countQueryBuilder = this.baseFilterQueryBuilder(range);
+        countQueryBuilder = this.baseFilterQueryBuilder(startDate, range);
         break;
     }
 
     countQueryBuilder.select("repos.id", "repos_id");
 
-    const countFilters = this.filterService.getRepoFilters(pageOptionsDto, range);
+    const countFilters = this.filterService.getRepoFilters(pageOptionsDto, startDate, range);
 
     if (!pageOptionsDto.repoIds) {
-      countFilters.push([`now() - INTERVAL '${range} days' <= "repos"."updated_at"`, { range }]);
+      countFilters.push([`'${startDate}'::DATE >= "repos"."updated_at"`, { range }]);
+      countFilters.push([`'${startDate}'::DATE - INTERVAL '${range} days' <= "repos"."updated_at"`, { range }]);
     }
 
     this.filterService.applyQueryBuilderFilters(countQueryBuilder, countFilters);
@@ -436,6 +447,7 @@ export class RepoService {
 
   async findOrgsRecommendations(userId: number, pageOptionsDto: PageOptionsDto) {
     const queryBuilder = this.baseFilterQueryBuilder();
+    const startDate = GetPrevDateISOString(pageOptionsDto.prev_days_start_date);
     const range = pageOptionsDto.range!;
 
     queryBuilder
@@ -451,7 +463,8 @@ export class RepoService {
         "repos.full_name LIKE user_orgs.login || '/%'"
       )
       .where("user_orgs.user_id = :userId", { userId })
-      .andWhere(`now() - INTERVAL '${range} days' <= "repos"."updated_at"`)
+      .andWhere(`'${startDate}'::DATE >= "repos"."updated_at"`)
+      .andWhere(`'${startDate}'::DATE - INTERVAL '${range} days' <= "repos"."updated_at"`)
       .orderBy("repos.stars", pageOptionsDto.orderDirection)
       .addOrderBy("repos.updated_at", pageOptionsDto.orderDirection);
 

--- a/src/user/user-highlights.service.ts
+++ b/src/user/user-highlights.service.ts
@@ -2,6 +2,7 @@ import { ConflictException, Injectable, NotFoundException, UnauthorizedException
 import { Repository, SelectQueryBuilder } from "typeorm";
 import { InjectRepository } from "@nestjs/typeorm";
 
+import { GetPrevDateISOString } from "../common/util/datetimes";
 import { PageOptionsDto } from "../common/dtos/page-options.dto";
 import { PageDto } from "../common/dtos/page.dto";
 import { PageMetaDto } from "../common/dtos/page-meta.dto";
@@ -111,6 +112,7 @@ export class UserHighlightsService {
 
   async findTop(pageOptionsDto: PageOptionsDto): Promise<PageDto<DbUserHighlight>> {
     const queryBuilder = this.baseQueryBuilder();
+    const startDate = GetPrevDateISOString(pageOptionsDto.prev_days_start_date);
     const range = pageOptionsDto.range!;
 
     queryBuilder
@@ -122,7 +124,8 @@ export class UserHighlightsService {
       `,
         "reactions"
       )
-      .where(`now() - INTERVAL '${range} days' <= user_highlights.created_at`)
+      .where(`'${startDate}'::DATE >= user_highlights.created_at`)
+      .andWhere(`'${startDate}'::DATE - INTERVAL '${range} days' <= user_highlights.created_at`)
       .limit(10)
       .orderBy("reactions", "DESC");
 


### PR DESCRIPTION
## Description

This allows for more dynamic timeblocks for contributor insights. I.e., set the "start" date for when churn, new, etc. contributors are determined. This introduces the `prev_days_start_date` param which are the number of days to go back to in order to start the range block. The default is `0` which maintains the current behavior of using `now()` blocks in the sql. 

Here's an example that uses `user/prs` where `0` days are used as the previous day start date:

```sh
curl -X 'GET' \
  'http://localhost:3003/v1/users/jpmcb/prs?page=1&limit=10&range=30&prev_days_start_date=0' \
  -H 'accept: application/json'
```

```json5
{
  "data": [
    {
      "id": 1520390100,
      "repo_id": 499330806,
      "number": 312,
      "state": "OPEN",
      "draft": true,
      "merged": false,
      "mergeable": false,
      "rebaseable": false,
      "title": "feat: Dynamic contributor timeblocks for insights",
      "source_label": "",
      "target_label": "",
      "source_branch": "jpmcb:insight-cards",
      "target_branch": "open-sauced:beta",
      "author_login": "jpmcb",
      "author_avatar": "https://avatars.githubusercontent.com/u/23109390?u=385f5ea55c6a932878eed020c2f96111209d0d11&v=4",
      "assignee_login": "",
      "assignee_avatar": "",
      "created_at": "2023-09-19T05:50:46.000Z",
      "closed_at": null,
      "merged_at": null,
      "merged_by_login": "",
      "updated_at": "2023-09-19T05:50:46.000Z",
      "last_updated_at": "2023-09-19T22:01:56.340Z", // last updated ... just a few minutes ago!
      "comments": 0,
      "additions": 51,
      "deletions": 15,
      "changed_files": 3,
      "full_name": "open-sauced/api",
      "commits": 1
    },
    // ... truncated
  ],
  "meta": {
    "page": 1,
    "limit": 10,
    "itemCount": 23,
    "pageCount": 3,
    "hasPreviousPage": false,
    "hasNextPage": true
  }
}
```

And here's the same query but where the previous week (`prev_days_start_date=7`) is used as the start date:

```sh
curl -X 'GET' \
  'http://localhost:3003/v1/users/jpmcb/prs?page=1&limit=10&range=30&prev_days_start_date=7' \
  -H 'accept: application/json'
```

```json5
{
  "data": [
    {
      "id": 1505361491,
      "repo_id": 499330806,
      "number": 297,
      "state": "MERGED",
      "draft": false,
      "merged": true,
      "mergeable": false,
      "rebaseable": false,
      "title": "feat: User-lists collaborators CRUD endpoints",
      "source_label": "",
      "target_label": "",
      "source_branch": "jpmcb:user-list-collaborators",
      "target_branch": "open-sauced:beta",
      "author_login": "jpmcb",
      "author_avatar": "https://avatars.githubusercontent.com/u/23109390?u=385f5ea55c6a932878eed020c2f96111209d0d11&v=4",
      "assignee_login": "",
      "assignee_avatar": "",
      "created_at": "2023-09-07T04:16:29.000Z",
      "closed_at": "2023-09-09T01:20:29.000Z",
      "merged_at": "2023-09-09T01:20:29.000Z",
      "merged_by_login": "brandonroberts",
      "updated_at": "2023-09-09T02:12:37.000Z",  // last updated last week, 7 days ago!
      "last_updated_at": "2023-09-19T22:01:56.340Z",
      "comments": 2,
      "additions": 772,
      "deletions": 311,
      "changed_files": 9,
      "full_name": "open-sauced/api",
      "commits": 1
    },
    // ... truncated
  ],
  "meta": {
    "page": 1,
    "limit": 10,
    "itemCount": 31,
    "pageCount": 4,
    "hasPreviousPage": false,
    "hasNextPage": true
  }
}
```

## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

Related to https://github.com/open-sauced/app/pull/1616
and: https://github.com/open-sauced/engineering/issues/125

## Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->


## Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 docs.opensauced.pizza
- [ ] 🍕 dev.to/opensauced
- [ ] 📕 storybook
- [ ] 🙅 no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?



## [optional] What gif best describes this PR or how it makes you feel?



<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
