### PR TITLE
feat: Initial `lists/:id/stats` features

### DIFF
--- a/src/user-lists/dtos/contributions-timeframe.dto.ts
+++ b/src/user-lists/dtos/contributions-timeframe.dto.ts
@@ -1,0 +1,27 @@
+import { IsEnum, IsIn, IsInt, IsOptional } from "class-validator";
+
+import { ApiPropertyOptional } from "@nestjs/swagger";
+import { Type } from "class-transformer";
+import { UserListContributorStatsTypeEnum } from "./most-active-contributors.dto";
+
+export class ContributionsTimeframeDto {
+  @ApiPropertyOptional({
+    description: "Range in days",
+    default: 30,
+    type: "integer",
+  })
+  @Type(() => Number)
+  @IsIn([7, 30, 90])
+  @IsInt()
+  @IsOptional()
+  readonly range?: number = 30;
+
+  @ApiPropertyOptional({
+    enum: UserListContributorStatsTypeEnum,
+    enumName: "UserListContributorStatsTypeEnum",
+    default: UserListContributorStatsTypeEnum.all,
+  })
+  @IsEnum(UserListContributorStatsTypeEnum)
+  @IsOptional()
+  contributorType?: UserListContributorStatsTypeEnum = UserListContributorStatsTypeEnum.all;
+}

--- a/src/user-lists/dtos/most-active-contributors.dto.ts
+++ b/src/user-lists/dtos/most-active-contributors.dto.ts
@@ -5,7 +5,7 @@ import { PageOptionsDto } from "../../common/dtos/page-options.dto";
 
 export enum UserListContributorStatsOrderEnum {
   commits = "commits",
-  prsCreated = "prsCreated",
+  prs_created = "prs_created",
 }
 
 export enum UserListContributorStatsTypeEnum {

--- a/src/user-lists/dtos/most-active-contributors.dto.ts
+++ b/src/user-lists/dtos/most-active-contributors.dto.ts
@@ -1,0 +1,36 @@
+import { IsEnum, IsOptional } from "class-validator";
+
+import { ApiPropertyOptional } from "@nestjs/swagger";
+import { PageOptionsDto } from "../../common/dtos/page-options.dto";
+
+export enum UserListContributorStatsOrderEnum {
+  commits = "commits",
+  prsCreated = "prsCreated",
+}
+
+export enum UserListContributorStatsTypeEnum {
+  all = "all",
+  active = "active",
+  new = "new",
+  alumni = "alumni",
+}
+
+export class UserListMostActiveContributorsDto extends PageOptionsDto {
+  @ApiPropertyOptional({
+    enum: UserListContributorStatsTypeEnum,
+    enumName: "UserListContributorStatsTypeEnum",
+    default: UserListContributorStatsTypeEnum.all,
+  })
+  @IsEnum(UserListContributorStatsTypeEnum)
+  @IsOptional()
+  contributorType?: UserListContributorStatsTypeEnum = UserListContributorStatsTypeEnum.all;
+
+  @ApiPropertyOptional({
+    enum: UserListContributorStatsOrderEnum,
+    enumName: "UserListContributorStatsOrderEnum",
+    default: UserListContributorStatsOrderEnum.commits,
+  })
+  @IsEnum(UserListContributorStatsOrderEnum)
+  @IsOptional()
+  readonly orderBy?: UserListContributorStatsOrderEnum = UserListContributorStatsOrderEnum.commits;
+}

--- a/src/user-lists/entities/contributions-projects.entity.ts
+++ b/src/user-lists/entities/contributions-projects.entity.ts
@@ -13,7 +13,7 @@ export class DbContributionsProjects {
     select: false,
     insert: false,
   })
-  orgId: string;
+  org_id: string;
 
   @ApiModelProperty({
     description: "The project name of the repo",
@@ -25,7 +25,7 @@ export class DbContributionsProjects {
     select: false,
     insert: false,
   })
-  projectId: string;
+  project_id: string;
 
   @ApiModelProperty({
     description: "The number of contributions associated with a org/repo",

--- a/src/user-lists/entities/contributions-projects.entity.ts
+++ b/src/user-lists/entities/contributions-projects.entity.ts
@@ -1,8 +1,41 @@
-import { Entity } from "typeorm";
+import { ApiModelProperty } from "@nestjs/swagger/dist/decorators/api-model-property.decorator";
+import { Column, Entity } from "typeorm";
 
 @Entity({ name: "user_list_contributors" })
 export class DbContributionsProjects {
+  @ApiModelProperty({
+    description: "The org name of the repo",
+    example: 0,
+    type: "string",
+  })
+  @Column({
+    type: "string",
+    select: false,
+    insert: false,
+  })
   orgId: string;
+
+  @ApiModelProperty({
+    description: "The project name of the repo",
+    example: 0,
+    type: "string",
+  })
+  @Column({
+    type: "string",
+    select: false,
+    insert: false,
+  })
   projectId: string;
+
+  @ApiModelProperty({
+    description: "The number of contributions associated with a org/repo",
+    example: 0,
+    type: "integer",
+  })
+  @Column({
+    type: "bigint",
+    select: false,
+    insert: false,
+  })
   contributions: number;
 }

--- a/src/user-lists/entities/contributions-projects.entity.ts
+++ b/src/user-lists/entities/contributions-projects.entity.ts
@@ -1,0 +1,8 @@
+import { Entity } from "typeorm";
+
+@Entity({ name: "user_list_contributors" })
+export class DbContributionsProjects {
+  orgId: string;
+  projectId: string;
+  contributions: number;
+}

--- a/src/user-lists/entities/contributions-timeframe.entity.ts
+++ b/src/user-lists/entities/contributions-timeframe.entity.ts
@@ -1,0 +1,13 @@
+import { Entity } from "typeorm";
+
+@Entity({ name: "user_list_contributors" })
+export class DbContributionStatTimeframe {
+  timeStart: string;
+  timeEnd: string;
+
+  commits: number;
+  prsCreated: number;
+  prsReviewed: number;
+  issuesCreated: number;
+  comments: number;
+}

--- a/src/user-lists/entities/contributions-timeframe.entity.ts
+++ b/src/user-lists/entities/contributions-timeframe.entity.ts
@@ -4,8 +4,8 @@ import { Column, Entity } from "typeorm";
 @Entity({ name: "user_list_contributors" })
 export class DbContributionStatTimeframe {
   @ApiModelProperty({
-    description: "The ISO timestamp of the start of the time frame",
-    example: 0,
+    description: "The ISO timestamp for the start of the time frame",
+    example: "2023-08-26T23:55:49.204Z",
     type: "string",
   })
   @Column({
@@ -13,11 +13,11 @@ export class DbContributionStatTimeframe {
     select: false,
     insert: false,
   })
-  timeStart: string;
+  time_start: string;
 
   @ApiModelProperty({
-    description: "The ISO timestamp of the end of the time frame",
-    example: 0,
+    description: "The ISO timestamp for the end of the time frame",
+    example: "2023-08-26T23:55:49.204Z",
     type: "string",
   })
   @Column({
@@ -25,7 +25,7 @@ export class DbContributionStatTimeframe {
     select: false,
     insert: false,
   })
-  timeEnd: string;
+  time_end: string;
 
   @ApiModelProperty({
     description: "Number of commits associated with a user login",
@@ -40,7 +40,7 @@ export class DbContributionStatTimeframe {
   commits: number;
 
   @ApiModelProperty({
-    description: "Number of PRs associated with a user login",
+    description: "Number of PRs created associated with a user login",
     example: 0,
     type: "integer",
   })
@@ -49,7 +49,7 @@ export class DbContributionStatTimeframe {
     select: false,
     insert: false,
   })
-  prsCreated: number;
+  prs_created: number;
 
   @ApiModelProperty({
     description: "Number of PRs reviewed by a user login",
@@ -61,7 +61,7 @@ export class DbContributionStatTimeframe {
     select: false,
     insert: false,
   })
-  prsReviewed: number;
+  prs_reviewed: number;
 
   @ApiModelProperty({
     description: "Number of issues created by a user login",
@@ -73,7 +73,7 @@ export class DbContributionStatTimeframe {
     select: false,
     insert: false,
   })
-  issuesCreated: number;
+  issues_created: number;
 
   @ApiModelProperty({
     description: "Number of comments associated with a user login",

--- a/src/user-lists/entities/contributions-timeframe.entity.ts
+++ b/src/user-lists/entities/contributions-timeframe.entity.ts
@@ -1,13 +1,89 @@
-import { Entity } from "typeorm";
+import { ApiModelProperty } from "@nestjs/swagger/dist/decorators/api-model-property.decorator";
+import { Column, Entity } from "typeorm";
 
 @Entity({ name: "user_list_contributors" })
 export class DbContributionStatTimeframe {
+  @ApiModelProperty({
+    description: "The ISO timestamp of the start of the time frame",
+    example: 0,
+    type: "string",
+  })
+  @Column({
+    type: "string",
+    select: false,
+    insert: false,
+  })
   timeStart: string;
+
+  @ApiModelProperty({
+    description: "The ISO timestamp of the end of the time frame",
+    example: 0,
+    type: "string",
+  })
+  @Column({
+    type: "string",
+    select: false,
+    insert: false,
+  })
   timeEnd: string;
 
+  @ApiModelProperty({
+    description: "Number of commits associated with a user login",
+    example: 0,
+    type: "integer",
+  })
+  @Column({
+    type: "bigint",
+    select: false,
+    insert: false,
+  })
   commits: number;
+
+  @ApiModelProperty({
+    description: "Number of PRs associated with a user login",
+    example: 0,
+    type: "integer",
+  })
+  @Column({
+    type: "bigint",
+    select: false,
+    insert: false,
+  })
   prsCreated: number;
+
+  @ApiModelProperty({
+    description: "Number of PRs reviewed by a user login",
+    example: 0,
+    type: "integer",
+  })
+  @Column({
+    type: "bigint",
+    select: false,
+    insert: false,
+  })
   prsReviewed: number;
+
+  @ApiModelProperty({
+    description: "Number of issues created by a user login",
+    example: 0,
+    type: "integer",
+  })
+  @Column({
+    type: "bigint",
+    select: false,
+    insert: false,
+  })
   issuesCreated: number;
+
+  @ApiModelProperty({
+    description: "Number of comments associated with a user login",
+    example: 0,
+    type: "integer",
+  })
+  @Column({
+    type: "bigint",
+    select: false,
+    insert: false,
+  })
   comments: number;
 }

--- a/src/user-lists/entities/contributors-timeframe.entity.ts
+++ b/src/user-lists/entities/contributors-timeframe.entity.ts
@@ -1,12 +1,58 @@
-import { Entity } from "typeorm";
+import { ApiModelProperty } from "@nestjs/swagger/dist/decorators/api-model-property.decorator";
+import { Column, Entity } from "typeorm";
 
 @Entity({ name: "user_list_contributors" })
 export class DbContributorCategoryTimeframe {
   timeStart: string;
   timeEnd: string;
 
+  @ApiModelProperty({
+    description: "Number of all contributors (active, new, and alumni)",
+    example: 0,
+    type: "integer",
+  })
+  @Column({
+    type: "bigint",
+    select: false,
+    insert: false,
+  })
   all: number;
+
+  @ApiModelProperty({
+    description: "Number of contributors who contributed in current time frame and previous time frame",
+    example: 0,
+    type: "integer",
+  })
+  @Column({
+    type: "bigint",
+    select: false,
+    insert: false,
+  })
   active: number;
+
+  @ApiModelProperty({
+    description:
+      "Number of contributors who are new to contributing (contributed in current time frame but not the previous time frame)",
+    example: 0,
+    type: "integer",
+  })
+  @Column({
+    type: "bigint",
+    select: false,
+    insert: false,
+  })
   new: number;
+
+  @ApiModelProperty({
+    description:
+      "Number of contributors who did not contribut in current time frame but did in the previous time frame",
+    example: 0,
+    type: "integer",
+  })
+  @Column({
+    type: "bigint",
+    select: false,
+    insert: false,
+  })
   alumni: number;
 }

--- a/src/user-lists/entities/contributors-timeframe.entity.ts
+++ b/src/user-lists/entities/contributors-timeframe.entity.ts
@@ -1,0 +1,12 @@
+import { Entity } from "typeorm";
+
+@Entity({ name: "user_list_contributors" })
+export class DbContributorCategoryTimeframe {
+  timeStart: string;
+  timeEnd: string;
+
+  all: number;
+  active: number;
+  new: number;
+  alumni: number;
+}

--- a/src/user-lists/entities/contributors-timeframe.entity.ts
+++ b/src/user-lists/entities/contributors-timeframe.entity.ts
@@ -3,8 +3,29 @@ import { Column, Entity } from "typeorm";
 
 @Entity({ name: "user_list_contributors" })
 export class DbContributorCategoryTimeframe {
-  timeStart: string;
-  timeEnd: string;
+  @ApiModelProperty({
+    description: "The ISO timestamp for the start of the time frame",
+    example: "2023-08-26T23:55:49.204Z",
+    type: "string",
+  })
+  @Column({
+    type: "string",
+    select: false,
+    insert: false,
+  })
+  time_start: string;
+
+  @ApiModelProperty({
+    description: "The ISO timestamp for the end of the time frame",
+    example: "2023-08-26T23:55:49.204Z",
+    type: "string",
+  })
+  @Column({
+    type: "string",
+    select: false,
+    insert: false,
+  })
+  time_end: string;
 
   @ApiModelProperty({
     description: "Number of all contributors (active, new, and alumni)",
@@ -45,7 +66,7 @@ export class DbContributorCategoryTimeframe {
 
   @ApiModelProperty({
     description:
-      "Number of contributors who did not contribut in current time frame but did in the previous time frame",
+      "Number of contributors who did not contribute in current time frame but did in the previous time frame",
     example: 0,
     type: "integer",
   })

--- a/src/user-lists/entities/user-list-contributor-stats.entity.ts
+++ b/src/user-lists/entities/user-list-contributor-stats.entity.ts
@@ -27,7 +27,7 @@ export class DbUserListContributorStat {
   commits: number;
 
   @ApiModelProperty({
-    description: "Number of PRs associated with a user login",
+    description: "Number of PRs created associated with a user login",
     example: 0,
     type: "integer",
   })
@@ -36,7 +36,7 @@ export class DbUserListContributorStat {
     select: false,
     insert: false,
   })
-  prsCreated: number;
+  prs_created: number;
 
   @ApiModelProperty({
     description: "Number of PRs reviewed by a user login",
@@ -48,7 +48,7 @@ export class DbUserListContributorStat {
     select: false,
     insert: false,
   })
-  prsReviewed: number;
+  prs_reviewed: number;
 
   @ApiModelProperty({
     description: "Number of issues created by a user login",
@@ -60,7 +60,7 @@ export class DbUserListContributorStat {
     select: false,
     insert: false,
   })
-  issuesCreated: number;
+  issues_created: number;
 
   @ApiModelProperty({
     description: "Number of comments associated with a user login",

--- a/src/user-lists/entities/user-list-contributor-stats.entity.ts
+++ b/src/user-lists/entities/user-list-contributor-stats.entity.ts
@@ -1,0 +1,22 @@
+import { Column, Entity } from "typeorm";
+import { ApiModelProperty } from "@nestjs/swagger/dist/decorators/api-model-property.decorator";
+
+@Entity({ name: "user_list_contributors" })
+export class DbUserListContributorStat {
+  @ApiModelProperty({
+    description: "User list collaborator's login",
+    example: "bdougie",
+  })
+  @Column({
+    type: "text",
+    select: false,
+    insert: false,
+  })
+  public login?: string;
+
+  commits: number;
+  prsCreated: number;
+  prsReviewed: number;
+  issuesCreated: number;
+  comments: number;
+}

--- a/src/user-lists/entities/user-list-contributor-stats.entity.ts
+++ b/src/user-lists/entities/user-list-contributor-stats.entity.ts
@@ -14,9 +14,63 @@ export class DbUserListContributorStat {
   })
   public login?: string;
 
+  @ApiModelProperty({
+    description: "Number of commits associated with a user login",
+    example: 0,
+    type: "integer",
+  })
+  @Column({
+    type: "bigint",
+    select: false,
+    insert: false,
+  })
   commits: number;
+
+  @ApiModelProperty({
+    description: "Number of PRs associated with a user login",
+    example: 0,
+    type: "integer",
+  })
+  @Column({
+    type: "bigint",
+    select: false,
+    insert: false,
+  })
   prsCreated: number;
+
+  @ApiModelProperty({
+    description: "Number of PRs reviewed by a user login",
+    example: 0,
+    type: "integer",
+  })
+  @Column({
+    type: "bigint",
+    select: false,
+    insert: false,
+  })
   prsReviewed: number;
+
+  @ApiModelProperty({
+    description: "Number of issues created by a user login",
+    example: 0,
+    type: "integer",
+  })
+  @Column({
+    type: "bigint",
+    select: false,
+    insert: false,
+  })
   issuesCreated: number;
+
+  @ApiModelProperty({
+    description: "Number of comments associated with a user login",
+    example: 0,
+    type: "integer",
+  })
+  @Column({
+    type: "bigint",
+    select: false,
+    insert: false,
+  })
   comments: number;
 }

--- a/src/user-lists/user-list-stat.service.ts
+++ b/src/user-lists/user-list-stat.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from "@nestjs/common";
+import { Injectable, NotFoundException } from "@nestjs/common";
 import { Repository, SelectQueryBuilder } from "typeorm";
 import { InjectRepository } from "@nestjs/typeorm";
 
@@ -11,6 +11,9 @@ import {
   UserListContributorStatsTypeEnum,
   UserListMostActiveContributorsDto,
 } from "./dtos/most-active-contributors.dto";
+import { ContributionsTimeframeDto } from "./dtos/contributions-timeframe.dto";
+import { DbContributionStatTimeframe } from "./entities/contributions-timeframe.entity";
+import { DbContributionsProjects } from "./entities/contributions-projects.entity";
 
 @Injectable()
 export class UserListStatsService {
@@ -30,6 +33,7 @@ export class UserListStatsService {
     listId: string
   ): Promise<PageDto<DbUserListContributorStat>> {
     const range = pageOptionsDto.range!;
+    const now = new Date().toISOString();
 
     const queryBuilder = this.baseQueryBuilder();
 
@@ -40,81 +44,15 @@ export class UserListStatsService {
         break;
 
       case UserListContributorStatsTypeEnum.active:
-        queryBuilder
-          .leftJoin(
-            `(
-            SELECT DISTINCT "author_login"
-            FROM "pull_requests"
-            WHERE "pull_requests"."updated_at" BETWEEN NOW() - INTERVAL '${range} days'
-              AND NOW()
-          )`,
-            "current_month_prs",
-            `"users"."login" = "current_month_prs"."author_login"`
-          )
-          .leftJoin(
-            `(
-            SELECT DISTINCT "author_login"
-            FROM "pull_requests"
-            WHERE "pull_requests"."updated_at" BETWEEN NOW() - INTERVAL '${range + range} days'
-              AND NOW() - INTERVAL '${range} days'
-          )`,
-            "previous_month_prs",
-            `"users"."login" = "previous_month_prs"."author_login"`
-          )
-          .where(`"previous_month_prs"."author_login" IS NOT NULL`)
-          .andWhere(`"current_month_prs"."author_login" IS NOT NULL`);
+        this.applyActiveContributorsFilter(queryBuilder, now, range);
         break;
 
       case UserListContributorStatsTypeEnum.new:
-        queryBuilder
-          .leftJoin(
-            `(
-            SELECT DISTINCT "author_login"
-            FROM "pull_requests"
-            WHERE "pull_requests"."updated_at" BETWEEN NOW() - INTERVAL '${range} days'
-              AND NOW()
-          )`,
-            "current_month_prs",
-            `"users"."login" = "current_month_prs"."author_login"`
-          )
-          .leftJoin(
-            `(
-            SELECT DISTINCT "author_login"
-            FROM "pull_requests"
-            WHERE "pull_requests"."updated_at" BETWEEN NOW() - INTERVAL '${range + range} days'
-              AND NOW() - INTERVAL '${range} days'
-          )`,
-            "previous_month_prs",
-            `"users"."login" = "previous_month_prs"."author_login"`
-          )
-          .where(`"previous_month_prs"."author_login" IS NOT NULL`)
-          .andWhere(`"current_month_prs"."author_login" IS NULL`);
+        this.applyNewContributorsFilter(queryBuilder, now, range);
         break;
 
       case UserListContributorStatsTypeEnum.alumni: {
-        queryBuilder
-          .leftJoin(
-            `(
-            SELECT DISTINCT "author_login"
-            FROM "pull_requests"
-            WHERE "pull_requests"."updated_at" BETWEEN NOW() - INTERVAL '${range} days'
-              AND NOW()
-          )`,
-            "current_month_prs",
-            `"users"."login" = "current_month_prs"."author_login"`
-          )
-          .leftJoin(
-            `(
-            SELECT DISTINCT "author_login"
-            FROM "pull_requests"
-            WHERE "pull_requests"."updated_at" BETWEEN NOW() - INTERVAL '${range + range} days'
-              AND NOW() - INTERVAL '${range} days'
-          )`,
-            "previous_month_prs",
-            `"users"."login" = "previous_month_prs"."author_login"`
-          )
-          .where(`"previous_month_prs"."author_login" IS NULL`)
-          .andWhere(`"current_month_prs"."author_login" IS NOT NULL`);
+        this.applyAlumniContributorsFilter(queryBuilder, now, range);
         break;
       }
 
@@ -163,5 +101,237 @@ export class UserListStatsService {
     const pageMetaDto = new PageMetaDto({ itemCount, pageOptionsDto });
 
     return new PageDto(entities, pageMetaDto);
+  }
+
+  async findContributionsInTimeframe(
+    options: ContributionsTimeframeDto,
+    listId: string
+  ): Promise<DbContributionStatTimeframe[]> {
+    const range = options.range!;
+    const contributorType = options.contributorType!;
+    const dates = this.getDateFrames(range);
+
+    const framePromises = dates.map(async (frameStartDate) =>
+      this.findContributionsInTimeframeHelper(frameStartDate.toISOString(), range / 7, contributorType, listId)
+    );
+
+    return Promise.all(framePromises);
+  }
+
+  getDateFrames(range = 30): Date[] {
+    const currentDate = new Date();
+    const frameDuration = range / 7;
+    const dates: Date[] = [];
+
+    // eslint-disable-next-line no-loops/no-loops
+    for (let i = 0; i < 7; i++) {
+      const frameDate = new Date(currentDate.getTime() - (range - i * frameDuration) * 86400000);
+
+      dates.push(frameDate);
+    }
+
+    return dates;
+  }
+
+  async findContributionsInTimeframeHelper(
+    startDate: string,
+    range: number,
+    contributorType: string,
+    listId: string
+  ): Promise<DbContributionStatTimeframe> {
+    const subQueryBuilder = this.baseQueryBuilder();
+
+    subQueryBuilder.innerJoin(
+      "users",
+      "users",
+      `user_list_contributors.user_id=users.id AND user_list_contributors.list_id='${listId}'`
+    );
+
+    switch (contributorType) {
+      case UserListContributorStatsTypeEnum.all:
+        break;
+
+      case UserListContributorStatsTypeEnum.active:
+        this.applyActiveContributorsFilter(subQueryBuilder, startDate, range);
+        break;
+
+      case UserListContributorStatsTypeEnum.new:
+        this.applyNewContributorsFilter(subQueryBuilder, startDate, range);
+        break;
+
+      case UserListContributorStatsTypeEnum.alumni: {
+        this.applyAlumniContributorsFilter(subQueryBuilder, startDate, range);
+        break;
+      }
+
+      default:
+        break;
+    }
+
+    subQueryBuilder
+      .addSelect(
+        `(
+          SELECT COALESCE(SUM("pull_requests"."commits"), 0)
+          FROM "pull_requests"
+          WHERE "pull_requests"."author_login" = "users"."login"
+            AND "pull_requests"."updated_at" > '${startDate}'::DATE - INTERVAL '${range} days'
+            AND "pull_requests"."updated_at" <= '${startDate}'::DATE
+        )::INTEGER`,
+        "all_commits"
+      )
+      .addSelect(
+        `(
+          SELECT COALESCE(COUNT("pull_requests"."id"), 0)
+          FROM "pull_requests"
+          WHERE "pull_requests"."author_login" = "users"."login"
+            AND "pull_requests"."updated_at" > '${startDate}'::DATE - INTERVAL '${range} days'
+            AND "pull_requests"."updated_at" <= '${startDate}'::DATE
+        )::INTEGER`,
+        "all_prsCreated"
+      );
+
+    const queryBuilder = this.userListContributorRepository.manager
+      .createQueryBuilder()
+      .select(`SUM("subQ"."all_commits")`, "commits")
+      .addSelect(`SUM("subQ"."all_prsCreated")`, "prsCreated")
+      .from(`( ${subQueryBuilder.getQuery()} )`, "subQ")
+      .setParameters(subQueryBuilder.getParameters());
+
+    const entity: DbContributionStatTimeframe | undefined = await queryBuilder.getRawOne();
+
+    if (!entity) {
+      throw new NotFoundException();
+    }
+
+    entity.timeStart = startDate;
+    entity.timeEnd = `${new Date(new Date(startDate).getTime() + range * 86400000).toISOString()}`;
+
+    return entity;
+  }
+
+  async findContributionsByProject(listId: string): Promise<DbContributionsProjects[]> {
+    // todo (jpmcb) - in the future we'll likely want to make this range dynamic.
+    const range = 30;
+
+    const queryBuilder = this.userListContributorRepository.manager
+      .createQueryBuilder()
+      .select("split_part(repos.full_name, '/', 1)", "orgId")
+      .addSelect("split_part(repos.full_name, '/', 2)", "projectId")
+      .addSelect("COUNT(pr.id)", "contributions")
+
+      // grab pull requests first
+      .from("pull_requests", "pr")
+
+      // and join them with repos
+      .innerJoin("repos", "repos", 'pr."repo_id" = "repos"."id"')
+
+      // join with filtered users from the user list
+      .innerJoin(
+        (subQuery) =>
+          subQuery
+            .select("users.login", "user_login")
+            .from("user_list_contributors", "user_list_contributors")
+            .innerJoin("users", "users", '"user_list_contributors"."user_id" = "users"."id"')
+            .where(`"user_list_contributors"."list_id" = '${listId}'`),
+        "filtered_users",
+        'pr."author_login" = "filtered_users"."user_login"'
+      )
+
+      .where(`pr."updated_at" BETWEEN NOW() - INTERVAL '${range} days' AND NOW()`)
+      .groupBy("repos.full_name");
+
+    const entities: DbContributionsProjects[] = await queryBuilder.getRawMany();
+
+    return entities;
+  }
+
+  private applyActiveContributorsFilter(
+    queryBuilder: SelectQueryBuilder<DbUserListContributor>,
+    startDate: string,
+    range = 30
+  ) {
+    queryBuilder
+      .leftJoin(
+        `(
+        SELECT DISTINCT "author_login"
+        FROM "pull_requests"
+        WHERE "pull_requests"."updated_at" BETWEEN '${startDate}'::DATE - INTERVAL '${range} days'
+          AND '${startDate}'::DATE
+      )`,
+        "current_month_prs",
+        `"users"."login" = "current_month_prs"."author_login"`
+      )
+      .leftJoin(
+        `(
+        SELECT DISTINCT "author_login"
+        FROM "pull_requests"
+        WHERE "pull_requests"."updated_at" BETWEEN '${startDate}'::DATE - INTERVAL '${range + range} days'
+          AND '${startDate}'::DATE - INTERVAL '${range} days'
+      )`,
+        "previous_month_prs",
+        `"users"."login" = "previous_month_prs"."author_login"`
+      )
+      .where(`"previous_month_prs"."author_login" IS NOT NULL`)
+      .andWhere(`"current_month_prs"."author_login" IS NOT NULL`);
+  }
+
+  private applyNewContributorsFilter(
+    queryBuilder: SelectQueryBuilder<DbUserListContributor>,
+    startDate: string,
+    range = 30
+  ) {
+    queryBuilder
+      .leftJoin(
+        `(
+            SELECT DISTINCT "author_login"
+            FROM "pull_requests"
+            WHERE "pull_requests"."updated_at" BETWEEN NOW() - INTERVAL '${range} days'
+              AND '${startDate}'::DATE
+          )`,
+        "current_month_prs",
+        `"users"."login" = "current_month_prs"."author_login"`
+      )
+      .leftJoin(
+        `(
+            SELECT DISTINCT "author_login"
+            FROM "pull_requests"
+            WHERE "pull_requests"."updated_at" BETWEEN NOW() - INTERVAL '${range + range} days'
+              AND '${startDate}'::DATE - INTERVAL "${range} days"
+          )`,
+        "previous_month_prs",
+        `"users"."login" = "previous_month_prs"."author_login"`
+      )
+      .where(`"previous_month_prs"."author_login" IS NOT NULL`)
+      .andWhere(`"current_month_prs"."author_login" IS NULL`);
+  }
+
+  private applyAlumniContributorsFilter(
+    queryBuilder: SelectQueryBuilder<DbUserListContributor>,
+    startDate: string,
+    range = 30
+  ) {
+    queryBuilder
+      .leftJoin(
+        `(
+            SELECT DISTINCT "author_login"
+            FROM "pull_requests"
+            WHERE "pull_requests"."updated_at" BETWEEN '${startDate}'::DATE - INTERVAL '${range} days'
+              AND '${startDate}'::DATE
+          )`,
+        "current_month_prs",
+        `"users"."login" = "current_month_prs"."author_login"`
+      )
+      .leftJoin(
+        `(
+            SELECT DISTINCT "author_login"
+            FROM "pull_requests"
+            WHERE "pull_requests"."updated_at" BETWEEN '${startDate}'::DATE - INTERVAL '${range + range} days'
+              AND '${startDate}'::DATE - INTERVAL '${range} days'
+          )`,
+        "previous_month_prs",
+        `"users"."login" = "previous_month_prs"."author_login"`
+      )
+      .where(`"previous_month_prs"."author_login" IS NULL`)
+      .andWhere(`"current_month_prs"."author_login" IS NOT NULL`);
   }
 }

--- a/src/user-lists/user-list-stat.service.ts
+++ b/src/user-lists/user-list-stat.service.ts
@@ -56,6 +56,9 @@ export class UserListStatsService {
         "prsCreated"
       );
 
+    // limit to only the top 20 contributors for stats by projects
+    queryBuilder.limit(20);
+
     const entities: DbUserListContributorStat[] = await queryBuilder.getRawMany();
 
     return entities;
@@ -129,6 +132,9 @@ export class UserListStatsService {
     }
 
     const itemCount = await queryBuilder.getCount();
+
+    queryBuilder.offset(pageOptionsDto.skip).limit(pageOptionsDto.limit);
+
     const entities: DbUserListContributorStat[] = await queryBuilder.getRawMany();
 
     const pageMetaDto = new PageMetaDto({ itemCount, pageOptionsDto });

--- a/src/user-lists/user-list-stat.service.ts
+++ b/src/user-lists/user-list-stat.service.ts
@@ -53,7 +53,7 @@ export class UserListStatsService {
           WHERE "pull_requests"."author_login" = "users"."login"
             AND "pull_requests"."repo_id" = ${repoId}
         )::INTEGER`,
-        "prsCreated"
+        "prs_created"
       );
 
     // limit to only the top 20 contributors for stats by projects
@@ -115,7 +115,7 @@ export class UserListStatsService {
           WHERE "pull_requests"."author_login" = "users"."login"
             AND now() - INTERVAL '${range} days' <= "pull_requests"."updated_at"
         )::INTEGER`,
-        "prsCreated"
+        "prs_created"
       );
 
     switch (pageOptionsDto.orderBy) {
@@ -123,8 +123,8 @@ export class UserListStatsService {
         queryBuilder.orderBy(`"${UserListContributorStatsOrderEnum.commits}"`, pageOptionsDto.orderDirection);
         break;
 
-      case UserListContributorStatsOrderEnum.prsCreated:
-        queryBuilder.orderBy(`"${UserListContributorStatsOrderEnum.prsCreated}"`, pageOptionsDto.orderDirection);
+      case UserListContributorStatsOrderEnum.prs_created:
+        queryBuilder.orderBy(`"${UserListContributorStatsOrderEnum.prs_created}"`, pageOptionsDto.orderDirection);
         break;
 
       default:
@@ -241,13 +241,13 @@ export class UserListStatsService {
             AND "pull_requests"."updated_at" > '${startDate}'::DATE - INTERVAL '${range} days'
             AND "pull_requests"."updated_at" <= '${startDate}'::DATE
         )::INTEGER`,
-        "all_prsCreated"
+        "all_prs_created"
       );
 
     const queryBuilder = this.userListContributorRepository.manager
       .createQueryBuilder()
       .select(`SUM("subQ"."all_commits")`, "commits")
-      .addSelect(`SUM("subQ"."all_prsCreated")`, "prsCreated")
+      .addSelect(`SUM("subQ"."all_prs_created")`, "prs_created")
       .from(`( ${subQueryBuilder.getQuery()} )`, "subQ")
       .setParameters(subQueryBuilder.getParameters());
 
@@ -257,8 +257,8 @@ export class UserListStatsService {
       throw new NotFoundException();
     }
 
-    entity.timeStart = startDate;
-    entity.timeEnd = `${new Date(new Date(startDate).getTime() + range * 86400000).toISOString()}`;
+    entity.time_start = startDate;
+    entity.time_end = `${new Date(new Date(startDate).getTime() + range * 86400000).toISOString()}`;
 
     return entity;
   }
@@ -305,8 +305,8 @@ export class UserListStatsService {
     const alumniCount = await alumniCountQueryBuilder.getCount();
 
     return {
-      timeStart: startDate,
-      timeEnd: `${new Date(new Date(startDate).getTime() + range * 86400000).toISOString()}`,
+      time_start: startDate,
+      time_end: `${new Date(new Date(startDate).getTime() + range * 86400000).toISOString()}`,
       active: activeCount,
       new: newCount,
       alumni: alumniCount,
@@ -320,8 +320,8 @@ export class UserListStatsService {
 
     const queryBuilder = this.userListContributorRepository.manager
       .createQueryBuilder()
-      .select("split_part(repos.full_name, '/', 1)", "orgId")
-      .addSelect("split_part(repos.full_name, '/', 2)", "projectId")
+      .select("split_part(repos.full_name, '/', 1)", "org_id")
+      .addSelect("split_part(repos.full_name, '/', 2)", "project_id")
       .addSelect("COUNT(pr.id)", "contributions")
 
       // grab pull requests first

--- a/src/user-lists/user-list-stat.service.ts
+++ b/src/user-lists/user-list-stat.service.ts
@@ -1,0 +1,167 @@
+import { Injectable } from "@nestjs/common";
+import { Repository, SelectQueryBuilder } from "typeorm";
+import { InjectRepository } from "@nestjs/typeorm";
+
+import { PageDto } from "../common/dtos/page.dto";
+import { PageMetaDto } from "../common/dtos/page-meta.dto";
+import { DbUserListContributor } from "./entities/user-list-contributor.entity";
+import { DbUserListContributorStat } from "./entities/user-list-contributor-stats.entity";
+import {
+  UserListContributorStatsOrderEnum,
+  UserListContributorStatsTypeEnum,
+  UserListMostActiveContributorsDto,
+} from "./dtos/most-active-contributors.dto";
+
+@Injectable()
+export class UserListStatsService {
+  constructor(
+    @InjectRepository(DbUserListContributor, "ApiConnection")
+    private userListContributorRepository: Repository<DbUserListContributor>
+  ) {}
+
+  baseQueryBuilder(): SelectQueryBuilder<DbUserListContributor> {
+    const builder = this.userListContributorRepository.createQueryBuilder("user_list_contributors");
+
+    return builder;
+  }
+
+  async findContributorStatsByListId(
+    pageOptionsDto: UserListMostActiveContributorsDto,
+    listId: string
+  ): Promise<PageDto<DbUserListContributorStat>> {
+    const range = pageOptionsDto.range!;
+
+    const queryBuilder = this.baseQueryBuilder();
+
+    queryBuilder.innerJoin("users", "users", "user_list_contributors.user_id=users.id");
+
+    switch (pageOptionsDto.contributorType) {
+      case UserListContributorStatsTypeEnum.all:
+        break;
+
+      case UserListContributorStatsTypeEnum.active:
+        queryBuilder
+          .leftJoin(
+            `(
+            SELECT DISTINCT "author_login"
+            FROM "pull_requests"
+            WHERE "pull_requests"."updated_at" BETWEEN NOW() - INTERVAL '${range} days'
+              AND NOW()
+          )`,
+            "current_month_prs",
+            `"users"."login" = "current_month_prs"."author_login"`
+          )
+          .leftJoin(
+            `(
+            SELECT DISTINCT "author_login"
+            FROM "pull_requests"
+            WHERE "pull_requests"."updated_at" BETWEEN NOW() - INTERVAL '${range + range} days'
+              AND NOW() - INTERVAL '${range} days'
+          )`,
+            "previous_month_prs",
+            `"users"."login" = "previous_month_prs"."author_login"`
+          )
+          .where(`"previous_month_prs"."author_login" IS NOT NULL`)
+          .andWhere(`"current_month_prs"."author_login" IS NOT NULL`);
+        break;
+
+      case UserListContributorStatsTypeEnum.new:
+        queryBuilder
+          .leftJoin(
+            `(
+            SELECT DISTINCT "author_login"
+            FROM "pull_requests"
+            WHERE "pull_requests"."updated_at" BETWEEN NOW() - INTERVAL '${range} days'
+              AND NOW()
+          )`,
+            "current_month_prs",
+            `"users"."login" = "current_month_prs"."author_login"`
+          )
+          .leftJoin(
+            `(
+            SELECT DISTINCT "author_login"
+            FROM "pull_requests"
+            WHERE "pull_requests"."updated_at" BETWEEN NOW() - INTERVAL '${range + range} days'
+              AND NOW() - INTERVAL '${range} days'
+          )`,
+            "previous_month_prs",
+            `"users"."login" = "previous_month_prs"."author_login"`
+          )
+          .where(`"previous_month_prs"."author_login" IS NOT NULL`)
+          .andWhere(`"current_month_prs"."author_login" IS NULL`);
+        break;
+
+      case UserListContributorStatsTypeEnum.alumni: {
+        queryBuilder
+          .leftJoin(
+            `(
+            SELECT DISTINCT "author_login"
+            FROM "pull_requests"
+            WHERE "pull_requests"."updated_at" BETWEEN NOW() - INTERVAL '${range} days'
+              AND NOW()
+          )`,
+            "current_month_prs",
+            `"users"."login" = "current_month_prs"."author_login"`
+          )
+          .leftJoin(
+            `(
+            SELECT DISTINCT "author_login"
+            FROM "pull_requests"
+            WHERE "pull_requests"."updated_at" BETWEEN NOW() - INTERVAL '${range + range} days'
+              AND NOW() - INTERVAL '${range} days'
+          )`,
+            "previous_month_prs",
+            `"users"."login" = "previous_month_prs"."author_login"`
+          )
+          .where(`"previous_month_prs"."author_login" IS NULL`)
+          .andWhere(`"current_month_prs"."author_login" IS NOT NULL`);
+        break;
+      }
+
+      default:
+        break;
+    }
+
+    queryBuilder
+      .select("users.login", "login")
+      .andWhere("user_list_contributors.list_id = :listId", { listId })
+      .addSelect(
+        `(
+          SELECT SUM("pull_requests"."commits")
+          FROM "pull_requests"
+          WHERE "pull_requests"."author_login" = "users"."login"
+            AND now() - INTERVAL '${range} days' <= "pull_requests"."updated_at"
+        )::INTEGER`,
+        "commits"
+      )
+      .addSelect(
+        `(
+          SELECT COALESCE(COUNT("pull_requests"."id"), 0)
+          FROM "pull_requests"
+          WHERE "pull_requests"."author_login" = "users"."login"
+            AND now() - INTERVAL '${range} days' <= "pull_requests"."updated_at"
+        )::INTEGER`,
+        "prsCreated"
+      );
+
+    switch (pageOptionsDto.orderBy) {
+      case UserListContributorStatsOrderEnum.commits:
+        queryBuilder.orderBy(`"${UserListContributorStatsOrderEnum.commits}"`, pageOptionsDto.orderDirection);
+        break;
+
+      case UserListContributorStatsOrderEnum.prsCreated:
+        queryBuilder.orderBy(`"${UserListContributorStatsOrderEnum.prsCreated}"`, pageOptionsDto.orderDirection);
+        break;
+
+      default:
+        break;
+    }
+
+    const itemCount = await queryBuilder.getCount();
+    const entities: DbUserListContributorStat[] = await queryBuilder.getRawMany();
+
+    const pageMetaDto = new PageMetaDto({ itemCount, pageOptionsDto });
+
+    return new PageDto(entities, pageMetaDto);
+  }
+}

--- a/src/user-lists/user-list-stats.controller.ts
+++ b/src/user-lists/user-list-stats.controller.ts
@@ -12,6 +12,7 @@ import {
 import { PageDto } from "../common/dtos/page.dto";
 import { SupabaseGuard } from "../auth/supabase.guard";
 
+import { ApiPaginatedResponse } from "../common/decorators/api-paginated-response.decorator";
 import { UserListMostActiveContributorsDto } from "./dtos/most-active-contributors.dto";
 import { DbUserListContributorStat } from "./entities/user-list-contributor-stats.entity";
 import { UserListStatsService } from "./user-list-stat.service";
@@ -19,7 +20,6 @@ import { DbContributionStatTimeframe } from "./entities/contributions-timeframe.
 import { ContributionsTimeframeDto } from "./dtos/contributions-timeframe.dto";
 import { DbContributionsProjects } from "./entities/contributions-projects.entity";
 import { DbContributorCategoryTimeframe } from "./entities/contributors-timeframe.entity";
-import { ApiPaginatedResponse } from "../common/decorators/api-paginated-response.decorator";
 
 @Controller("lists")
 @ApiTags("User Lists service")

--- a/src/user-lists/user-list-stats.controller.ts
+++ b/src/user-lists/user-list-stats.controller.ts
@@ -1,0 +1,42 @@
+import { Controller, Get, Param, Query, UseGuards } from "@nestjs/common";
+import {
+  ApiOperation,
+  ApiOkResponse,
+  ApiNotFoundResponse,
+  ApiBearerAuth,
+  ApiTags,
+  ApiBadRequestResponse,
+  ApiParam,
+} from "@nestjs/swagger";
+
+import { PageDto } from "../common/dtos/page.dto";
+import { SupabaseGuard } from "../auth/supabase.guard";
+
+import { DbUserList } from "./entities/user-list.entity";
+import { UserListMostActiveContributorsDto } from "./dtos/most-active-contributors.dto";
+import { DbUserListContributorStat } from "./entities/user-list-contributor-stats.entity";
+import { UserListStatsService } from "./user-list-stat.service";
+
+@Controller("lists")
+@ApiTags("User Lists service")
+export class UserListStatsController {
+  constructor(private readonly userListStatsService: UserListStatsService) {}
+
+  @Get(":id/stats/most-active-contributors")
+  @ApiOperation({
+    operationId: "getMostActiveContributors",
+    summary: "Gets most active contributors for a given list",
+  })
+  @ApiBearerAuth()
+  @UseGuards(SupabaseGuard)
+  @ApiOkResponse({ type: DbUserList })
+  @ApiNotFoundResponse({ description: "Unable to get user lists" })
+  @ApiBadRequestResponse({ description: "Invalid request" })
+  @ApiParam({ name: "id", type: "string" })
+  async getMostActiveContributors(
+    @Param("id") id: string,
+    @Query() pageOptionsDto: UserListMostActiveContributorsDto
+  ): Promise<PageDto<DbUserListContributorStat>> {
+    return this.userListStatsService.findContributorStatsByListId(pageOptionsDto, id);
+  }
+}

--- a/src/user-lists/user-list-stats.controller.ts
+++ b/src/user-lists/user-list-stats.controller.ts
@@ -39,7 +39,7 @@ export class UserListStatsController {
     @Param("id") id: string,
     @Query() pageOptionsDto: UserListMostActiveContributorsDto
   ): Promise<PageDto<DbUserListContributorStat>> {
-    return this.userListStatsService.findContributorStatsByListId(pageOptionsDto, id);
+    return this.userListStatsService.findAllListContributorStats(pageOptionsDto, id);
   }
 
   @Get(":id/stats/contributions-evolution-by-type")
@@ -73,5 +73,23 @@ export class UserListStatsController {
   @ApiParam({ name: "id", type: "string" })
   async getContributionsByProject(@Param("id") id: string): Promise<DbContributionsProjects[]> {
     return this.userListStatsService.findContributionsByProject(id);
+  }
+
+  @Get(":id/stats/top-project-contributions-by-contributor/")
+  @ApiOperation({
+    operationId: "getContributorContributionsByProject",
+    summary: "Gets top 20 contributor stats in a list by a given project",
+  })
+  @ApiBearerAuth()
+  @UseGuards(SupabaseGuard)
+  @ApiOkResponse({ type: DbUserListContributorStat })
+  @ApiNotFoundResponse({ description: "Unable to get contributions" })
+  @ApiBadRequestResponse({ description: "Invalid request" })
+  @ApiParam({ name: "id", type: "string" })
+  async getContributorContributionsByProject(
+    @Param("id") id: string,
+    @Query("repoId") repoId: number
+  ): Promise<DbUserListContributorStat[]> {
+    return this.userListStatsService.findListContributorStatsByProject(id, repoId);
   }
 }

--- a/src/user-lists/user-list-stats.controller.ts
+++ b/src/user-lists/user-list-stats.controller.ts
@@ -18,6 +18,7 @@ import { UserListStatsService } from "./user-list-stat.service";
 import { DbContributionStatTimeframe } from "./entities/contributions-timeframe.entity";
 import { ContributionsTimeframeDto } from "./dtos/contributions-timeframe.dto";
 import { DbContributionsProjects } from "./entities/contributions-projects.entity";
+import { DbContributorCategoryTimeframe } from "./entities/contributors-timeframe.entity";
 
 @Controller("lists")
 @ApiTags("User Lists service")
@@ -90,6 +91,25 @@ export class UserListStatsController {
     @Param("id") id: string,
     @Query("repoId") repoId: number
   ): Promise<DbUserListContributorStat[]> {
+    // todo need only top 20.
     return this.userListStatsService.findListContributorStatsByProject(id, repoId);
+  }
+
+  @Get(":id/stats/contributions-evolution-by-contributor-type")
+  @ApiOperation({
+    operationId: "getContributorsByTimeframe",
+    summary: "Gets contributions by category within timeframe",
+  })
+  @ApiBearerAuth()
+  @UseGuards(SupabaseGuard)
+  @ApiOkResponse({ type: DbContributorCategoryTimeframe })
+  @ApiNotFoundResponse({ description: "Unable to get contributions" })
+  @ApiBadRequestResponse({ description: "Invalid request" })
+  @ApiParam({ name: "id", type: "string" })
+  async getContributionsByTimeframe(
+    @Param("id") id: string,
+    @Query() options: ContributionsTimeframeDto
+  ): Promise<DbContributorCategoryTimeframe[]> {
+    return this.userListStatsService.findContributorCategoriesByTimeframe(options, id);
   }
 }

--- a/src/user-lists/user-list-stats.controller.ts
+++ b/src/user-lists/user-list-stats.controller.ts
@@ -19,6 +19,7 @@ import { DbContributionStatTimeframe } from "./entities/contributions-timeframe.
 import { ContributionsTimeframeDto } from "./dtos/contributions-timeframe.dto";
 import { DbContributionsProjects } from "./entities/contributions-projects.entity";
 import { DbContributorCategoryTimeframe } from "./entities/contributors-timeframe.entity";
+import { ApiPaginatedResponse } from "../common/decorators/api-paginated-response.decorator";
 
 @Controller("lists")
 @ApiTags("User Lists service")
@@ -32,8 +33,9 @@ export class UserListStatsController {
   })
   @ApiBearerAuth()
   @UseGuards(SupabaseGuard)
-  @ApiOkResponse({ type: PageDto<DbUserListContributorStat> })
-  @ApiNotFoundResponse({ description: "Unable to get user lists" })
+  @ApiPaginatedResponse(DbUserListContributorStat)
+  @ApiOkResponse({ type: DbUserListContributorStat })
+  @ApiNotFoundResponse({ description: "Unable to get list most active contributors" })
   @ApiBadRequestResponse({ description: "Invalid request" })
   @ApiParam({ name: "id", type: "string" })
   async getMostActiveContributors(
@@ -69,7 +71,7 @@ export class UserListStatsController {
   @ApiBearerAuth()
   @UseGuards(SupabaseGuard)
   @ApiOkResponse({ type: DbContributionsProjects })
-  @ApiNotFoundResponse({ description: "Unable to get contributions" })
+  @ApiNotFoundResponse({ description: "Unable to get contributions by project" })
   @ApiBadRequestResponse({ description: "Invalid request" })
   @ApiParam({ name: "id", type: "string" })
   async getContributionsByProject(@Param("id") id: string): Promise<DbContributionsProjects[]> {

--- a/src/user-lists/user-list-stats.controller.ts
+++ b/src/user-lists/user-list-stats.controller.ts
@@ -91,7 +91,6 @@ export class UserListStatsController {
     @Param("id") id: string,
     @Query("repoId") repoId: number
   ): Promise<DbUserListContributorStat[]> {
-    // todo need only top 20.
     return this.userListStatsService.findListContributorStatsByProject(id, repoId);
   }
 

--- a/src/user-lists/user-list-stats.controller.ts
+++ b/src/user-lists/user-list-stats.controller.ts
@@ -12,10 +12,12 @@ import {
 import { PageDto } from "../common/dtos/page.dto";
 import { SupabaseGuard } from "../auth/supabase.guard";
 
-import { DbUserList } from "./entities/user-list.entity";
 import { UserListMostActiveContributorsDto } from "./dtos/most-active-contributors.dto";
 import { DbUserListContributorStat } from "./entities/user-list-contributor-stats.entity";
 import { UserListStatsService } from "./user-list-stat.service";
+import { DbContributionStatTimeframe } from "./entities/contributions-timeframe.entity";
+import { ContributionsTimeframeDto } from "./dtos/contributions-timeframe.dto";
+import { DbContributionsProjects } from "./entities/contributions-projects.entity";
 
 @Controller("lists")
 @ApiTags("User Lists service")
@@ -29,7 +31,7 @@ export class UserListStatsController {
   })
   @ApiBearerAuth()
   @UseGuards(SupabaseGuard)
-  @ApiOkResponse({ type: DbUserList })
+  @ApiOkResponse({ type: PageDto<DbUserListContributorStat> })
   @ApiNotFoundResponse({ description: "Unable to get user lists" })
   @ApiBadRequestResponse({ description: "Invalid request" })
   @ApiParam({ name: "id", type: "string" })
@@ -38,5 +40,38 @@ export class UserListStatsController {
     @Query() pageOptionsDto: UserListMostActiveContributorsDto
   ): Promise<PageDto<DbUserListContributorStat>> {
     return this.userListStatsService.findContributorStatsByListId(pageOptionsDto, id);
+  }
+
+  @Get(":id/stats/contributions-evolution-by-type")
+  @ApiOperation({
+    operationId: "getContributionsByTimeFrame",
+    summary: "Gets contributions in a given timeframe",
+  })
+  @ApiBearerAuth()
+  @UseGuards(SupabaseGuard)
+  @ApiOkResponse({ type: DbContributionStatTimeframe })
+  @ApiNotFoundResponse({ description: "Unable to get contributions" })
+  @ApiBadRequestResponse({ description: "Invalid request" })
+  @ApiParam({ name: "id", type: "string" })
+  async getContributionsByTimeFrame(
+    @Param("id") id: string,
+    @Query() options: ContributionsTimeframeDto
+  ): Promise<DbContributionStatTimeframe[]> {
+    return this.userListStatsService.findContributionsInTimeframe(options, id);
+  }
+
+  @Get(":id/stats/contributions-by-project")
+  @ApiOperation({
+    operationId: "getContributionsByProject",
+    summary: "Gets contributions in a given timeframe",
+  })
+  @ApiBearerAuth()
+  @UseGuards(SupabaseGuard)
+  @ApiOkResponse({ type: DbContributionsProjects })
+  @ApiNotFoundResponse({ description: "Unable to get contributions" })
+  @ApiBadRequestResponse({ description: "Invalid request" })
+  @ApiParam({ name: "id", type: "string" })
+  async getContributionsByProject(@Param("id") id: string): Promise<DbContributionsProjects[]> {
+    return this.userListStatsService.findContributionsByProject(id);
   }
 }

--- a/src/user-lists/user-list.module.ts
+++ b/src/user-lists/user-list.module.ts
@@ -4,19 +4,26 @@ import { TypeOrmModule } from "@nestjs/typeorm";
 import { UserModule } from "../user/user.module";
 import { ApiServicesModule } from "../common/services/api-services.module";
 import { DbUser } from "../user/user.entity";
+import { DbPullRequest } from "../pull-requests/entities/pull-request.entity";
 import { DbUserListContributor } from "./entities/user-list-contributor.entity";
 import { DbUserList } from "./entities/user-list.entity";
 import { UserListService } from "./user-list.service";
 import { UserListController } from "./user-list.controller";
+import { UserListStatsService } from "./user-list-stat.service";
+import { UserListStatsController } from "./user-list-stats.controller";
+import { DbUserListContributorStat } from "./entities/user-list-contributor-stats.entity";
 
 @Module({
   imports: [
     ApiServicesModule,
     UserModule,
-    TypeOrmModule.forFeature([DbUser, DbUserList, DbUserListContributor], "ApiConnection"),
+    TypeOrmModule.forFeature(
+      [DbUser, DbUserList, DbPullRequest, DbUserListContributor, DbUserListContributorStat],
+      "ApiConnection"
+    ),
   ],
-  controllers: [UserListController],
-  providers: [UserListService],
-  exports: [UserListService],
+  controllers: [UserListController, UserListStatsController],
+  providers: [UserListService, UserListStatsService],
+  exports: [UserListService, UserListStatsService],
 })
 export class UserListModule {}

--- a/src/user-lists/user-list.module.ts
+++ b/src/user-lists/user-list.module.ts
@@ -13,6 +13,7 @@ import { UserListStatsService } from "./user-list-stat.service";
 import { UserListStatsController } from "./user-list-stats.controller";
 import { DbUserListContributorStat } from "./entities/user-list-contributor-stats.entity";
 import { DbContributionStatTimeframe } from "./entities/contributions-timeframe.entity";
+import { DbContributorCategoryTimeframe } from "./entities/contributors-timeframe.entity";
 
 @Module({
   imports: [
@@ -26,6 +27,7 @@ import { DbContributionStatTimeframe } from "./entities/contributions-timeframe.
         DbUserListContributor,
         DbUserListContributorStat,
         DbContributionStatTimeframe,
+        DbContributorCategoryTimeframe,
       ],
       "ApiConnection"
     ),

--- a/src/user-lists/user-list.module.ts
+++ b/src/user-lists/user-list.module.ts
@@ -12,13 +12,21 @@ import { UserListController } from "./user-list.controller";
 import { UserListStatsService } from "./user-list-stat.service";
 import { UserListStatsController } from "./user-list-stats.controller";
 import { DbUserListContributorStat } from "./entities/user-list-contributor-stats.entity";
+import { DbContributionStatTimeframe } from "./entities/contributions-timeframe.entity";
 
 @Module({
   imports: [
     ApiServicesModule,
     UserModule,
     TypeOrmModule.forFeature(
-      [DbUser, DbUserList, DbPullRequest, DbUserListContributor, DbUserListContributorStat],
+      [
+        DbUser,
+        DbUserList,
+        DbPullRequest,
+        DbUserListContributor,
+        DbUserListContributorStat,
+        DbContributionStatTimeframe,
+      ],
       "ApiConnection"
     ),
   ],


### PR DESCRIPTION
## Description

Implements the `list/:id/stats` endpoints - currently a WIP

### `/v1/lists/{id}/stats/most-active-contributors`

```sh
curl -X 'GET' \
  'http://localhost:3003/v1/lists/<list-id>/stats/most-active-contributors?page=1&limit=10&range=30&contributorType=all' \
  -H 'accept: application/json' \
  -H 'Authorization: Bearer <redacted>'
```

```json5
{
  "data": [
    {
      "login": "brandonroberts",
      "commits": 193,
      "prsCreated": 46
    },
    {
      "login": "jpmcb",
      "commits": 26,
      "prsCreated": 23
    }
  ],
  "meta": {
    "page": 1,
    "limit": 10,
    "itemCount": 2,
    "pageCount": 1,
    "hasPreviousPage": false,
    "hasNextPage": false
  }
}
```

This is a list I made with me and @brandonroberts on it. This route also supports
- `contributorType`:
  - `all` (everyone)
  - `active` (have contributed in the last 2 time date ranges)
  - `alumni` (have not contributed in the last time date range but did in the one prior to that)
  - `new` (have contributed in the last time date range but did not in the one prior to that)

- `orderBy`:
  - `commits` (the number of commits based on number of commits in prs)
  - `prsCreated` (the number of pull requests created)

### `/v1/lists/{id}/stats/contributions-evolution-by-type`

```sh
curl -X 'GET' \
  'http://localhost:3003/v1/lists/17e0f1c2-c556-4734-bfc4-86d43efc4087/stats/contributions-evolution-by-type?range=30' \
  -H 'accept: application/json' \
  -H 'Authorization: Bearer <readacted>'
```

```json5
[
  {
    "commits": 6,
    "prsCreated": 5,
    "timeStart": "2023-08-22T21:41:43.989Z",
    "timeEnd": "2023-08-27T04:33:09.703Z"
  },
  // truncated ...
  {
    "commits": 16,
    "prsCreated": 3,
    "timeStart": "2023-09-17T14:50:18.274Z",
    "timeEnd": "2023-09-21T21:41:43.988Z"
  }
]
```

- `range` can be specified to determine how far back to go. I made this so it'll always return 7 timeframes with `timeStart` and `timeEnd` being ISO date/time strings differentiating the frames that contain the blocks of data

### `/v1/lists/{id}/stats/contributions-by-project`

Returns an aggregate list of contributions for projects in a given list.

```sh
curl -X 'GET' \
  'http://localhost:3003/v1/lists/17e0f1c2-c556-4734-bfc4-86d43efc4087/stats/contributions-by-project' \
  -H 'accept: application/json' \
  -H 'Authorization: Bearer <redacted>'
```

```json5
[
  {
    "orgId": "analogjs",
    "projectId": "analog",
    "contributions": 10
  },
  {
    "orgId": "JeanMeche",
    "projectId": "riegler.fr",
    "contributions": 1
  },
  {
    "orgId": "ngrx",
    "projectId": "platform",
    "contributions": 1
  },
  {
    "orgId": "open-sauced",
    "projectId": "api",
    "contributions": 27
  },
  {
    "orgId": "open-sauced",
    "projectId": "app",
    "contributions": 21
  },
  {
    "orgId": "open-sauced",
    "projectId": "pizza",
    "contributions": 8
  },
  {
    "orgId": "open-sauced",
    "projectId": "pizza-cli",
    "contributions": 2
  },
  {
    "orgId": "open-sauced",
    "projectId": "repo-query",
    "contributions": 2
  }
]
```

### `/v1/lists/{id}/stats/contributions-evolution-by-type`

Returns 7 timestamp blocks that represent the time series for data of aggregate contributions, filtered by their type, in a given time block.

```sh
curl -X 'GET' \
  'http://localhost:3003/v1/lists/17e0f1c2-c556-4734-bfc4-86d43efc4087/stats/contributions-evolution-by-type?range=30' \
  -H 'accept: application/json' \
  -H 'Authorization: Bearer <redacted>'
```

```json5
[
  {
    "commits": 29,
    "prsCreated": 12,
    "timeStart": "2023-08-26T14:36:06.595Z",
    "timeEnd": "2023-08-30T21:27:32.309Z"
  },
  {
    "commits": 54,
    "prsCreated": 15,
    "timeStart": "2023-08-30T21:27:32.309Z",
    "timeEnd": "2023-09-04T04:18:58.023Z"
  },
  {
    "commits": 29,
    "prsCreated": 13,
    "timeStart": "2023-09-04T04:18:58.023Z",
    "timeEnd": "2023-09-08T11:10:23.737Z"
  },
  {
    "commits": 37,
    "prsCreated": 11,
    "timeStart": "2023-09-08T11:10:23.737Z",
    "timeEnd": "2023-09-12T18:01:49.451Z"
  },
  {
    "commits": 31,
    "prsCreated": 7,
    "timeStart": "2023-09-12T18:01:49.452Z",
    "timeEnd": "2023-09-17T00:53:15.166Z"
  },
  {
    "commits": 16,
    "prsCreated": 3,
    "timeStart": "2023-09-17T00:53:15.166Z",
    "timeEnd": "2023-09-21T07:44:40.880Z"
  },
  {
    "commits": 83,
    "prsCreated": 11,
    "timeStart": "2023-09-21T07:44:40.880Z",
    "timeEnd": "2023-09-25T14:36:06.594Z"
  }
]
```

- Can specify the `contributorType` to get only the types of contributions within the time range that are active/new/alumni/etc.

### `/v1/lists/{id}/stats/top-project-contributions-by-contributor`

Gets contributions from contributors for a certain project (`repoId` which maps to the `repos` table).

```sh
curl -X 'GET' \
  'http://localhost:3003/v1/lists/17e0f1c2-c556-4734-bfc4-86d43efc4087/stats/top-project-contributions-by-contributor?repoId=499330806' \
  -H 'accept: application/json' \
  -H 'Authorization: Bearer <redacted>'
```

(note that this is for `open-sauced/api` in my list with Brandon and me)

```json5
[
  {
    "login": "brandonroberts",
    "commits": 120,
    "prsCreated": 123
  },
  {
    "login": "jpmcb",
    "commits": 48,
    "prsCreated": 20
  }
]
```

### `/v1/lists/{id}/stats/contributions-evolution-by-contributor-type`

Returns 84 datapoints for a time series constructing the _type_ of contributions that have occurred in that time frame.

```sh
curl -X 'GET' \
  'http://localhost:3003/v1/lists/17e0f1c2-c556-4734-bfc4-86d43efc4087/stats/contributions-evolution-by-contributor-type?range=30' \
  -H 'accept: application/json' \
  -H 'Authorization: Bearer <redacted>'
```

```json5
[
  {
    "timeStart": "2023-08-26T14:46:43.695Z",
    "timeEnd": "2023-08-26T23:33:33.451Z",
    "active": 0,
    "new": 0,
    "alumni": 1,
    "all": 1
  },
  {
    "timeStart": "2023-08-26T23:33:33.451Z",
    "timeEnd": "2023-08-27T08:20:23.207Z",
    "active": 0,
    "new": 0,
    "alumni": 1,
    "all": 1
  },
  // ... truncated
  {
    "timeStart": "2023-09-24T21:13:04.182Z",
    "timeEnd": "2023-09-25T05:59:53.938Z",
    "active": 0,
    "new": 0,
    "alumni": 1,
    "all": 1
  },
  {
    "timeStart": "2023-09-25T05:59:53.938Z",
    "timeEnd": "2023-09-25T14:46:43.694Z",
    "active": 0,
    "new": 0,
    "alumni": 0,
    "all": 0
  }
]
```
---

Generally, I've left out a few feature asks from https://github.com/open-sauced/app/pull/1594. Primarily, we aren't directly indexing comments, pull requests reviews, or issues yet. So there's a gap in our data there.

See:

- https://github.com/open-sauced/api/issues/321
- https://github.com/open-sauced/api/issues/322
- https://github.com/open-sauced/api/issues/323

## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

Related to https://github.com/open-sauced/app/pull/1594 (cc @foxyblocks)

## Mobile & Desktop Screenshots/Recordings

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 docs.opensauced.pizza
- [ ] 🍕 dev.to/opensauced
- [ ] 📕 storybook
- [x] 🙅 no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?

Will need to validate and adjust with the front end components as we go.

## [optional] What gif best describes this PR or how it makes you feel?

![](https://media.tenor.com/XKJtQ4pZIqsAAAAC/shrek-meme-pinocho.gif)

<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
