### PR TITLE
feat: `GET /list/:id` able to be public for authenticated users

### DIFF
--- a/src/user-lists/entities/user-list.entity.ts
+++ b/src/user-lists/entities/user-list.entity.ts
@@ -36,7 +36,7 @@ export class DbUserList extends BaseEntity {
   })
   @Column({
     type: "bigint",
-    select: false,
+    select: true,
   })
   public user_id: number;
 

--- a/src/user-lists/user-list.controller.ts
+++ b/src/user-lists/user-list.controller.ts
@@ -81,7 +81,7 @@ export class UserListController {
   @ApiBadRequestResponse({ description: "Invalid request" })
   @ApiParam({ name: "id", type: "string" })
   async getUserList(@Param("id") id: string, @UserId() userId: number): Promise<DbUserList> {
-    return this.userListService.findOneById(id, userId);
+    return this.userListService.findPublicOneById(id, userId);
   }
 
   @Patch("/:id")


### PR DESCRIPTION
## Description

This PR is twofold:
- Surfaces the `user_id` when querying for a list via `GET list/:id`. This column previously was not selected
- Makes it so anyone can get a public list. Before, the `findOneById` the controller used would always only select lists that matched the `user_id` of the authenticated user.

Example of getting a public list for an authenticated user:
```
curl -X 'GET' \
  'http://localhost:3003/v1/lists/408a7817-87ad-4ec6-bd87-3c5c1687c05f' \
  -H 'accept: application/json' \
  -H 'Authorization: Bearer <redacted>'

{
  "id": "408a7817-87ad-4ec6-bd87-3c5c1687c05f",
  "user_id": 23109390,
  "name": "Woof",
  "is_public": true,
  "created_at": "2023-09-19T03:28:49.609Z",
  "updated_at": "2023-09-19T03:28:49.609Z",
  "deleted_at": null
}
```

Example of getting an auth error for a non public list:
```
curl -X 'GET' \
  'http://localhost:3003/v1/lists/17e0f1c2-c556-4734-bfc4-86d43efc4087' \
  -H 'accept: application/json' \
  -H 'Authorization: Bearer <redacted>'

{
  "statusCode": 401,
  "message": "You're not authorized to view this list",
  "error": "Unauthorized"
}
```

cc @nickytonline - Let me know if this needs anything else!

## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

Closes: https://github.com/open-sauced/api/issues/329

## Mobile & Desktop Screenshots/Recordings

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 docs.opensauced.pizza
- [ ] 🍕 dev.to/opensauced
- [ ] 📕 storybook
- [x] 🙅 no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![](https://media.giphy.com/media/aBN66chr4Y9na/giphy.gif)

<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
