### PR TITLE
fix: Refactors `::DATE` casts to `::TIMESTAMP` casting

### DIFF
--- a/src/common/filters/repo-filter.service.ts
+++ b/src/common/filters/repo-filter.service.ts
@@ -51,8 +51,8 @@ export class RepoFilterService {
           FROM "pull_requests" "spam_pull_requests"
           WHERE
             'spam' = ANY("spam_pull_requests"."label_names")
-            AND '${startDate}'::DATE >= "spam_pull_requests"."updated_at"
-            AND '${startDate}'::DATE - INTERVAL '${range} days' <= "spam_pull_requests"."updated_at"
+            AND '${startDate}'::TIMESTAMP >= "spam_pull_requests"."updated_at"
+            AND '${startDate}'::TIMESTAMP - INTERVAL '${range} days' <= "spam_pull_requests"."updated_at"
         )
       `,
         {},

--- a/src/pull-requests/pull-request-insights.service.ts
+++ b/src/pull-requests/pull-request-insights.service.ts
@@ -80,8 +80,8 @@ export class PullRequestInsightsService {
         break;
 
       default:
-        filters.push([`'${startDate}'::DATE >= "pr"."updated_at"`, {}]);
-        filters.push([`'${startDate}'::DATE - INTERVAL '${interval} days' <= "pr"."updated_at"`, {}]);
+        filters.push([`'${startDate}'::TIMESTAMP >= "pr"."updated_at"`, {}]);
+        filters.push([`'${startDate}'::TIMESTAMP - INTERVAL '${interval} days' <= "pr"."updated_at"`, {}]);
         break;
     }
 
@@ -107,7 +107,7 @@ export class PullRequestInsightsService {
 
       default:
         queryBuilder = this.baseQueryBuilder()
-          .select(`TO_CHAR('${startDate}'::DATE - INTERVAL '${interval} days', 'YYYY-MM-DD')`, "day")
+          .select(`TO_CHAR('${startDate}'::TIMESTAMP - INTERVAL '${interval} days', 'YYYY-MM-DD')`, "day")
           .addSelect(`${interval}::INTEGER`, "interval");
         break;
     }

--- a/src/pull-requests/pull-request.service.ts
+++ b/src/pull-requests/pull-request.service.ts
@@ -80,8 +80,8 @@ export class PullRequestService {
     queryBuilder
       .innerJoin("repos", "repos", `"pull_requests"."repo_id"="repos"."id"`)
       .where(`LOWER("pull_requests"."author_login")=:contributor`, { contributor: contributor.toLowerCase() })
-      .andWhere(`'${startDate}'::DATE >= "pull_requests"."updated_at"`)
-      .andWhere(`'${startDate}'::DATE - INTERVAL '${range} days' <= "pull_requests"."updated_at"`)
+      .andWhere(`'${startDate}'::TIMESTAMP >= "pull_requests"."updated_at"`)
+      .andWhere(`'${startDate}'::TIMESTAMP - INTERVAL '${range} days' <= "pull_requests"."updated_at"`)
       .addSelect("repos.full_name", "pull_requests_full_name")
       .addSelect("repos.id", "pull_requests_repo_id")
       .orderBy(`"pull_requests"."updated_at"`, OrderDirectionEnum.DESC)
@@ -114,8 +114,8 @@ export class PullRequestService {
         filters.push([this.hacktoberfestPrFilterBuilderEnd(range), {}]);
         break;
       default:
-        filters.push([`'${startDate}'::DATE >= "pull_requests"."updated_at"`, {}]);
-        filters.push([`'${startDate}'::DATE - INTERVAL '${range} days' <= "pull_requests"."updated_at"`, {}]);
+        filters.push([`'${startDate}'::TIMESTAMP >= "pull_requests"."updated_at"`, {}]);
+        filters.push([`'${startDate}'::TIMESTAMP - INTERVAL '${range} days' <= "pull_requests"."updated_at"`, {}]);
         break;
     }
 
@@ -129,7 +129,7 @@ export class PullRequestService {
     if (pageOptionsDto.listId) {
       filters.push([
         `author_login IN (
-          SELECT login FROM 
+          SELECT login FROM
           user_list_contributors
           JOIN users ON user_list_contributors.user_id=users.id AND users.deleted_at IS NULL
           WHERE list_id=:listId
@@ -184,8 +184,8 @@ export class PullRequestService {
         filters.push([this.hacktoberfestPrFilterBuilderEnd(range), {}]);
         break;
       default:
-        filters.push([`'${startDate}'::DATE >= "pull_requests"."updated_at"`, {}]);
-        filters.push([`'${startDate}'::DATE - INTERVAL '${range} days' <= "pull_requests"."updated_at"`, {}]);
+        filters.push([`'${startDate}'::TIMESTAMP >= "pull_requests"."updated_at"`, {}]);
+        filters.push([`'${startDate}'::TIMESTAMP - INTERVAL '${range} days' <= "pull_requests"."updated_at"`, {}]);
         break;
     }
 
@@ -233,8 +233,8 @@ export class PullRequestService {
             .distinct()
             .from(DbPullRequest, "pull_requests")
             .innerJoin("repos", "repos", `"pull_requests"."repo_id"="repos"."id"`)
-            .where(`pull_requests.updated_at >= '${startDate}'::DATE - INTERVAL '${range + range} days'`)
-            .andWhere(`pull_requests.updated_at < '${startDate}'::DATE - INTERVAL '${range} days'`)
+            .where(`pull_requests.updated_at >= '${startDate}'::TIMESTAMP - INTERVAL '${range + range} days'`)
+            .andWhere(`pull_requests.updated_at < '${startDate}'::TIMESTAMP - INTERVAL '${range} days'`)
             .andWhere("pull_requests.author_login != ''")
             .andWhere("repos.id IN (:...repoIds)", { repoIds }),
         "previous_month",
@@ -290,8 +290,8 @@ export class PullRequestService {
             .distinct()
             .from(DbPullRequest, "pull_requests")
             .innerJoin("repos", "repos", `"pull_requests"."repo_id"="repos"."id"`)
-            .where(`pull_requests.updated_at >= '${startDate}'::DATE - INTERVAL '${range} days'`)
-            .andWhere(`pull_requests.updated_at < '${startDate}'::DATE - INTERVAL '0 days'`)
+            .where(`pull_requests.updated_at >= '${startDate}'::TIMESTAMP - INTERVAL '${range} days'`)
+            .andWhere(`pull_requests.updated_at < '${startDate}'::TIMESTAMP - INTERVAL '0 days'`)
             .andWhere("pull_requests.author_login != ''")
             .andWhere("repos.id IN (:...repoIds)", { repoIds }),
         "current_month",
@@ -328,8 +328,8 @@ export class PullRequestService {
             .distinct()
             .from(DbPullRequest, "pull_requests")
             .innerJoin("repos", "repos", `"pull_requests"."repo_id"="repos"."id"`)
-            .where(`pull_requests.updated_at >= '${startDate}'::DATE - INTERVAL '${range} days'`)
-            .andWhere(`pull_requests.updated_at < '${startDate}'::DATE - INTERVAL '0 days'`)
+            .where(`pull_requests.updated_at >= '${startDate}'::TIMESTAMP - INTERVAL '${range} days'`)
+            .andWhere(`pull_requests.updated_at < '${startDate}'::TIMESTAMP - INTERVAL '0 days'`)
             .andWhere("pull_requests.author_login != ''")
             .andWhere("repos.id IN (:...repoIds)", { repoIds }),
         "current_month",
@@ -361,8 +361,8 @@ export class PullRequestService {
       .select("author_login")
       .distinct()
       .innerJoin("repos", "repos", `"pull_requests"."repo_id"="repos"."id"`)
-      .where(`pull_requests.updated_at >= '${start_date}'::DATE - INTERVAL '${end_range} days'`)
-      .andWhere(`pull_requests.updated_at < '${start_date}'::DATE - INTERVAL '${start_range} days'`)
+      .where(`pull_requests.updated_at >= '${start_date}'::TIMESTAMP - INTERVAL '${end_range} days'`)
+      .andWhere(`pull_requests.updated_at < '${start_date}'::TIMESTAMP - INTERVAL '${start_range} days'`)
       .andWhere("pull_requests.author_login != ''")
       .andWhere("repos.id IN (:...repoIds)", { repoIds });
 

--- a/src/repo/repo.service.ts
+++ b/src/repo/repo.service.ts
@@ -73,8 +73,8 @@ export class RepoService {
           WHERE
             LOWER("open_pull_requests"."state") = 'open'
             AND "open_pull_requests"."repo_id" = "repos"."id"
-            AND '${startDate}'::DATE >= "open_pull_requests"."updated_at"
-            AND '${startDate}'::DATE - INTERVAL '${range} days' <= "open_pull_requests"."updated_at"
+            AND '${startDate}'::TIMESTAMP >= "open_pull_requests"."updated_at"
+            AND '${startDate}'::TIMESTAMP - INTERVAL '${range} days' <= "open_pull_requests"."updated_at"
         )::INTEGER`,
         "repos_open_prs_count"
       )
@@ -86,8 +86,8 @@ export class RepoService {
             LOWER("closed_pull_requests"."state") = 'closed'
             AND "closed_pull_requests"."merged" = false
             AND "closed_pull_requests"."repo_id" = "repos"."id"
-            AND '${startDate}'::DATE >= "closed_pull_requests"."updated_at"
-            AND '${startDate}'::DATE - INTERVAL '${range} days' <= "closed_pull_requests"."updated_at"
+            AND '${startDate}'::TIMESTAMP >= "closed_pull_requests"."updated_at"
+            AND '${startDate}'::TIMESTAMP - INTERVAL '${range} days' <= "closed_pull_requests"."updated_at"
         )::INTEGER`,
         `repos_closed_prs_count`
       )
@@ -99,8 +99,8 @@ export class RepoService {
             (LOWER("merged_pull_requests"."state") = 'merged'
             OR "merged_pull_requests"."merged" = true)
             AND "merged_pull_requests"."repo_id" = "repos"."id"
-            AND '${startDate}'::DATE >= "merged_pull_requests"."updated_at"
-            AND '${startDate}'::DATE - INTERVAL '${range} days' <= "merged_pull_requests"."updated_at"
+            AND '${startDate}'::TIMESTAMP >= "merged_pull_requests"."updated_at"
+            AND '${startDate}'::TIMESTAMP - INTERVAL '${range} days' <= "merged_pull_requests"."updated_at"
         )::INTEGER`,
         `repos_merged_prs_count`
       )
@@ -111,8 +111,8 @@ export class RepoService {
           WHERE
             "draft_pull_requests"."draft" = true
             AND "draft_pull_requests"."repo_id" = "repos"."id"
-            AND '${startDate}'::DATE >= "draft_pull_requests"."updated_at"
-            AND '${startDate}'::DATE - INTERVAL '${range} days' <= "draft_pull_requests"."updated_at"
+            AND '${startDate}'::TIMESTAMP >= "draft_pull_requests"."updated_at"
+            AND '${startDate}'::TIMESTAMP - INTERVAL '${range} days' <= "draft_pull_requests"."updated_at"
         )::INTEGER`,
         `repos_draft_prs_count`
       )
@@ -123,8 +123,8 @@ export class RepoService {
           WHERE
             'spam' = ANY("spam_pull_requests"."label_names")
             AND "spam_pull_requests"."repo_id" = "repos"."id"
-            AND '${startDate}'::DATE >= "spam_pull_requests"."updated_at"
-            AND '${startDate}'::DATE - INTERVAL '${range} days' <= "spam_pull_requests"."updated_at"
+            AND '${startDate}'::TIMESTAMP >= "spam_pull_requests"."updated_at"
+            AND '${startDate}'::TIMESTAMP - INTERVAL '${range} days' <= "spam_pull_requests"."updated_at"
         )::INTEGER`,
         `repos_spam_prs_count`
       )
@@ -135,8 +135,8 @@ export class RepoService {
           WHERE
             "pull_requests_velocity"."repo_id" = "repos"."id"
             AND "pull_requests_velocity"."closed_at" > "pull_requests_velocity"."created_at"
-            AND '${startDate}'::DATE >= "pull_requests_velocity"."updated_at"
-            AND '${startDate}'::DATE - INTERVAL '${range} days' <= "pull_requests_velocity"."updated_at"
+            AND '${startDate}'::TIMESTAMP >= "pull_requests_velocity"."updated_at"
+            AND '${startDate}'::TIMESTAMP - INTERVAL '${range} days' <= "pull_requests_velocity"."updated_at"
         )::INTEGER`,
         `repos_pr_velocity_count`
       )
@@ -146,8 +146,8 @@ export class RepoService {
           FROM "pull_requests" "active_pull_requests"
           WHERE
             "active_pull_requests"."repo_id" = "repos"."id"
-            AND '${startDate}'::DATE >= "active_pull_requests"."updated_at"
-            AND '${startDate}'::DATE - INTERVAL '${range} days' <= "active_pull_requests"."updated_at"
+            AND '${startDate}'::TIMESTAMP >= "active_pull_requests"."updated_at"
+            AND '${startDate}'::TIMESTAMP - INTERVAL '${range} days' <= "active_pull_requests"."updated_at"
             AND "active_pull_requests".state != 'closed'
         )::INTEGER`,
         `repo_active_prs_count`
@@ -363,8 +363,8 @@ export class RepoService {
     const filters = this.filterService.getRepoFilters(pageOptionsDto, startDate, range);
 
     if (!pageOptionsDto.repoIds && !pageOptionsDto.repo) {
-      filters.push([`'${startDate}'::DATE >= "repos"."updated_at"`, { range }]);
-      filters.push([`'${startDate}'::DATE - INTERVAL '${range} days' <= "repos"."updated_at"`, { range }]);
+      filters.push([`'${startDate}'::TIMESTAMP >= "repos"."updated_at"`, { range }]);
+      filters.push([`'${startDate}'::TIMESTAMP - INTERVAL '${range} days' <= "repos"."updated_at"`, { range }]);
     }
 
     this.filterService.applyQueryBuilderFilters(queryBuilder, filters);
@@ -389,8 +389,8 @@ export class RepoService {
     const countFilters = this.filterService.getRepoFilters(pageOptionsDto, startDate, range);
 
     if (!pageOptionsDto.repoIds) {
-      countFilters.push([`'${startDate}'::DATE >= "repos"."updated_at"`, { range }]);
-      countFilters.push([`'${startDate}'::DATE - INTERVAL '${range} days' <= "repos"."updated_at"`, { range }]);
+      countFilters.push([`'${startDate}'::TIMESTAMP >= "repos"."updated_at"`, { range }]);
+      countFilters.push([`'${startDate}'::TIMESTAMP - INTERVAL '${range} days' <= "repos"."updated_at"`, { range }]);
     }
 
     this.filterService.applyQueryBuilderFilters(countQueryBuilder, countFilters);
@@ -463,8 +463,8 @@ export class RepoService {
         "repos.full_name LIKE user_orgs.login || '/%'"
       )
       .where("user_orgs.user_id = :userId", { userId })
-      .andWhere(`'${startDate}'::DATE >= "repos"."updated_at"`)
-      .andWhere(`'${startDate}'::DATE - INTERVAL '${range} days' <= "repos"."updated_at"`)
+      .andWhere(`'${startDate}'::TIMESTAMP >= "repos"."updated_at"`)
+      .andWhere(`'${startDate}'::TIMESTAMP - INTERVAL '${range} days' <= "repos"."updated_at"`)
       .orderBy("repos.stars", pageOptionsDto.orderDirection)
       .addOrderBy("repos.updated_at", pageOptionsDto.orderDirection);
 

--- a/src/user-lists/user-list-stat.service.ts
+++ b/src/user-lists/user-list-stat.service.ts
@@ -228,8 +228,8 @@ export class UserListStatsService {
           SELECT COALESCE(SUM("pull_requests"."commits"), 0)
           FROM "pull_requests"
           WHERE "pull_requests"."author_login" = "users"."login"
-            AND "pull_requests"."updated_at" > '${startDate}'::DATE - INTERVAL '${range} days'
-            AND "pull_requests"."updated_at" <= '${startDate}'::DATE
+            AND "pull_requests"."updated_at" > '${startDate}'::TIMESTAMP - INTERVAL '${range} days'
+            AND "pull_requests"."updated_at" <= '${startDate}'::TIMESTAMP
         )::INTEGER`,
         "all_commits"
       )
@@ -238,8 +238,8 @@ export class UserListStatsService {
           SELECT COALESCE(COUNT("pull_requests"."id"), 0)
           FROM "pull_requests"
           WHERE "pull_requests"."author_login" = "users"."login"
-            AND "pull_requests"."updated_at" > '${startDate}'::DATE - INTERVAL '${range} days'
-            AND "pull_requests"."updated_at" <= '${startDate}'::DATE
+            AND "pull_requests"."updated_at" > '${startDate}'::TIMESTAMP - INTERVAL '${range} days'
+            AND "pull_requests"."updated_at" <= '${startDate}'::TIMESTAMP
         )::INTEGER`,
         "all_prs_created"
       );
@@ -360,8 +360,8 @@ export class UserListStatsService {
         `(
         SELECT DISTINCT "author_login"
         FROM "pull_requests"
-        WHERE "pull_requests"."updated_at" BETWEEN '${startDate}'::DATE - INTERVAL '${range} days'
-          AND '${startDate}'::DATE
+        WHERE "pull_requests"."updated_at" BETWEEN '${startDate}'::TIMESTAMP - INTERVAL '${range} days'
+          AND '${startDate}'::TIMESTAMP
       )`,
         "current_month_prs",
         `"users"."login" = "current_month_prs"."author_login"`
@@ -370,8 +370,8 @@ export class UserListStatsService {
         `(
         SELECT DISTINCT "author_login"
         FROM "pull_requests"
-        WHERE "pull_requests"."updated_at" BETWEEN '${startDate}'::DATE - INTERVAL '${range + range} days'
-          AND '${startDate}'::DATE - INTERVAL '${range} days'
+        WHERE "pull_requests"."updated_at" BETWEEN '${startDate}'::TIMESTAMP - INTERVAL '${range + range} days'
+          AND '${startDate}'::TIMESTAMP - INTERVAL '${range} days'
       )`,
         "previous_month_prs",
         `"users"."login" = "previous_month_prs"."author_login"`
@@ -391,7 +391,7 @@ export class UserListStatsService {
             SELECT DISTINCT "author_login"
             FROM "pull_requests"
             WHERE "pull_requests"."updated_at" BETWEEN NOW() - INTERVAL '${range} days'
-              AND '${startDate}'::DATE
+              AND '${startDate}'::TIMESTAMP
           )`,
         "current_month_prs",
         `"users"."login" = "current_month_prs"."author_login"`
@@ -401,7 +401,7 @@ export class UserListStatsService {
             SELECT DISTINCT "author_login"
             FROM "pull_requests"
             WHERE "pull_requests"."updated_at" BETWEEN NOW() - INTERVAL '${range + range} days'
-              AND '${startDate}'::DATE - INTERVAL '${range} days'
+              AND '${startDate}'::TIMESTAMP - INTERVAL '${range} days'
           )`,
         "previous_month_prs",
         `"users"."login" = "previous_month_prs"."author_login"`
@@ -420,8 +420,8 @@ export class UserListStatsService {
         `(
             SELECT DISTINCT "author_login"
             FROM "pull_requests"
-            WHERE "pull_requests"."updated_at" BETWEEN '${startDate}'::DATE - INTERVAL '${range} days'
-              AND '${startDate}'::DATE
+            WHERE "pull_requests"."updated_at" BETWEEN '${startDate}'::TIMESTAMP - INTERVAL '${range} days'
+              AND '${startDate}'::TIMESTAMP
           )`,
         "current_month_prs",
         `"users"."login" = "current_month_prs"."author_login"`
@@ -430,8 +430,8 @@ export class UserListStatsService {
         `(
             SELECT DISTINCT "author_login"
             FROM "pull_requests"
-            WHERE "pull_requests"."updated_at" BETWEEN '${startDate}'::DATE - INTERVAL '${range + range} days'
-              AND '${startDate}'::DATE - INTERVAL '${range} days'
+            WHERE "pull_requests"."updated_at" BETWEEN '${startDate}'::TIMESTAMP - INTERVAL '${range + range} days'
+              AND '${startDate}'::TIMESTAMP - INTERVAL '${range} days'
           )`,
         "previous_month_prs",
         `"users"."login" = "previous_month_prs"."author_login"`

--- a/src/user/user-highlights.service.ts
+++ b/src/user/user-highlights.service.ts
@@ -124,8 +124,8 @@ export class UserHighlightsService {
       `,
         "reactions"
       )
-      .where(`'${startDate}'::DATE >= user_highlights.created_at`)
-      .andWhere(`'${startDate}'::DATE - INTERVAL '${range} days' <= user_highlights.created_at`)
+      .where(`'${startDate}'::TIMESTAMP >= user_highlights.created_at`)
+      .andWhere(`'${startDate}'::TIMESTAMP - INTERVAL '${range} days' <= user_highlights.created_at`)
       .limit(10)
       .orderBy("reactions", "DESC");
 


### PR DESCRIPTION
## Description

Throughout our psql calls, we had been using `::DATE` casts to filter queries based on sliding time windows.

These would truncate down ISO timestamps to remove the "time" precision from the date/time strings, leaving essentially just the date. However, when compared to _other_ timestamps we carry data for, we essentially re-cast the date to a timestamp with empty "time".

For example, when getting pull requests for a contributor:

https://github.com/open-sauced/api/blob/84a0e3c01be9d1bef36e219a9b66f265419478d0/src/pull-requests/pull-request.service.ts#L83

given the "startDate" is "NOW()", this would truncate the date ISO string down to something like `2023-10-05` DATE. This is equivalent to the timestamp `2023-10-05 00:00:00Z` which, when compared to _other_ timestamps within the current day, like for example, `2023-10-05 12:30:00`, it would get dropped even though it is well within the sliding time window.

This needs some pretty thorough end to end testing but upon some arbitrary tests, this fixes some issues we saw with recent PRs and things not showing up for people within their profiles for the last day.

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

Fixes https://github.com/open-sauced/app/issues/1800

## Mobile & Desktop Screenshots/Recordings

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 docs.opensauced.pizza
- [ ] 🍕 dev.to/opensauced
- [ ] 📕 storybook
- [x] 🙅 no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?

Again, need to validate and verify everything is still ok, especially when this lands on beta

## [optional] What gif best describes this PR or how it makes you feel?

![](https://media.giphy.com/media/xUOxfgwY8Tvj1DY5y0/giphy.gif)

<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
