### PR TITLE
fix: Coalesce on commits in list stats

### DIFF
--- a/src/user-lists/user-list-stat.service.ts
+++ b/src/user-lists/user-list-stat.service.ts
@@ -39,7 +39,7 @@ export class UserListStatsService {
       .andWhere("user_list_contributors.list_id = :listId", { listId })
       .addSelect(
         `(
-          SELECT SUM("pull_requests"."commits")
+          SELECT COALESCE(SUM("pull_requests"."commits"), 0)
           FROM "pull_requests"
           WHERE "pull_requests"."author_login" = "users"."login"
             AND "pull_requests"."repo_id" = ${repoId}
@@ -101,7 +101,7 @@ export class UserListStatsService {
       .andWhere("user_list_contributors.list_id = :listId", { listId })
       .addSelect(
         `(
-          SELECT SUM("pull_requests"."commits")
+          SELECT COALESCE(SUM("pull_requests"."commits"), 0)
           FROM "pull_requests"
           WHERE "pull_requests"."author_login" = "users"."login"
             AND now() - INTERVAL '${range} days' <= "pull_requests"."updated_at"


### PR DESCRIPTION
## Description

Fixes `commits` returned from the user list stats endpoints potentially having `null` as a value. This ensures that null values are 0 for user commit data.

#### Before

```json
{
  "data": [
    {
      "login": "0-vortex",
      "commits": null,
      "prs_created": 0
    },
    {
      "login": "nickytonline",
      "commits": 292,
      "prs_created": 21
    },
    {
      "login": "brandonroberts",
      "commits": 275,
      "prs_created": 44
    },
    {
      "login": "OgDev-01",
      "commits": 184,
      "prs_created": 15
    },
    {
      "login": "BekahHW",
      "commits": 52,
      "prs_created": 11
    },
    {
      "login": "jpmcb",
      "commits": 26,
      "prs_created": 15
    },
    {
      "login": "bdougie",
      "commits": 15,
      "prs_created": 4
    },
    {
      "login": "isabensusan",
      "commits": 11,
      "prs_created": 1
    }
  ],
  "meta": {
    "page": 1,
    "limit": 10,
    "itemCount": 8,
    "pageCount": 1,
    "hasPreviousPage": false,
    "hasNextPage": false
  }
}
```

#### After

```json
{
  "data": [
    {
      "login": "nickytonline",
      "commits": 292,
      "prs_created": 21
    },
    {
      "login": "brandonroberts",
      "commits": 275,
      "prs_created": 44
    },
    {
      "login": "OgDev-01",
      "commits": 184,
      "prs_created": 15
    },
    {
      "login": "BekahHW",
      "commits": 52,
      "prs_created": 11
    },
    {
      "login": "jpmcb",
      "commits": 26,
      "prs_created": 15
    },
    {
      "login": "bdougie",
      "commits": 15,
      "prs_created": 4
    },
    {
      "login": "isabensusan",
      "commits": 11,
      "prs_created": 1
    },
    {
      "login": "0-vortex",
      "commits": 0,
      "prs_created": 0
    }
  ],
  "meta": {
    "page": 1,
    "limit": 10,
    "itemCount": 8,
    "pageCount": 1,
    "hasPreviousPage": false,
    "hasNextPage": false
  }
}
```

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents
<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 
-->
Fixes #348

## Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->


## Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 docs.opensauced.pizza
- [ ] 🍕 dev.to/opensauced
- [ ] 📕 storybook
- [ ] 🙅 no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?



## [optional] What gif best describes this PR or how it makes you feel?



<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
