### PR TITLE
fix: Ordering for CTE based query

### DIFF
--- a/src/user-lists/user-list-stat.service.ts
+++ b/src/user-lists/user-list-stat.service.ts
@@ -123,23 +123,6 @@ export class UserListStatsService {
         "prs_created"
       );
 
-    switch (pageOptionsDto.orderBy) {
-      case UserListContributorStatsOrderEnum.commits:
-        cteBuilder.orderBy(`"${UserListContributorStatsOrderEnum.commits}"`, pageOptionsDto.orderDirection);
-        break;
-
-      case UserListContributorStatsOrderEnum.prs_created:
-        cteBuilder.orderBy(`"${UserListContributorStatsOrderEnum.prs_created}"`, pageOptionsDto.orderDirection);
-        break;
-
-      case UserListContributorStatsOrderEnum.total_contributions:
-        cteBuilder.orderBy(`"${UserListContributorStatsOrderEnum.total_contributions}"`, pageOptionsDto.orderDirection);
-        break;
-
-      default:
-        break;
-    }
-
     const entityQb = this.userListContributorRepository.manager
       .createQueryBuilder()
       .addCommonTableExpression(cteBuilder, "CTE")
@@ -149,6 +132,23 @@ export class UserListStatsService {
       .addSelect("prs_created")
       .addSelect(`("commits" + "prs_created") AS "total_contributions"`)
       .from("CTE", "CTE");
+
+    switch (pageOptionsDto.orderBy) {
+      case UserListContributorStatsOrderEnum.commits:
+        entityQb.orderBy(`"${UserListContributorStatsOrderEnum.commits}"`, pageOptionsDto.orderDirection);
+        break;
+
+      case UserListContributorStatsOrderEnum.prs_created:
+        entityQb.orderBy(`"${UserListContributorStatsOrderEnum.prs_created}"`, pageOptionsDto.orderDirection);
+        break;
+
+      case UserListContributorStatsOrderEnum.total_contributions:
+        entityQb.orderBy(`"${UserListContributorStatsOrderEnum.total_contributions}"`, pageOptionsDto.orderDirection);
+        break;
+
+      default:
+        break;
+    }
 
     const allCountQb = this.userListContributorRepository.manager
       .createQueryBuilder()


### PR DESCRIPTION
## Description

Followup to #352 

Fixes ordering not landing in derived field for `total_contributions` which happens after the CTE executes.

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

Related to https://github.com/open-sauced/app/pull/1796/commits/32bc78a536124727bbc0a6fe4e97367c69bb287f![]

## Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->


## Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 docs.opensauced.pizza
- [ ] 🍕 dev.to/opensauced
- [ ] 📕 storybook
- [ ] 🙅 no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?



## [optional] What gif best describes this PR or how it makes you feel?

![](https://media.giphy.com/media/RrVzUOXldFe8M/giphy.gif)

<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
