### PR TITLE
fix: user-lists stats for not found entities returns empty results

### DIFF
--- a/src/user-lists/user-list-stat.service.ts
+++ b/src/user-lists/user-list-stat.service.ts
@@ -171,7 +171,10 @@ export class UserListStatsService {
     const allContributionsResult: AllContributionsCount | undefined = await allCountQb.getRawOne();
 
     if (!allContributionsResult) {
-      throw new NotFoundException();
+      return new ContributionsPageDto(
+        new Array<DbUserListContributorStat>(),
+        new ContributionsPageMetaDto({ itemCount, pageOptionsDto }, 0)
+      );
     }
 
     const allContributionsCount = allContributionsResult.all_contributions;
@@ -289,8 +292,8 @@ export class UserListStatsService {
 
     const queryBuilder = this.userListContributorRepository.manager
       .createQueryBuilder()
-      .select(`SUM("subQ"."all_commits")`, "commits")
-      .addSelect(`SUM("subQ"."all_prs_created")`, "prs_created")
+      .select(`COALESCE(SUM("subQ"."all_commits"), 0)`, "commits")
+      .addSelect(`COALESCE(SUM("subQ"."all_prs_created"), 0)`, "prs_created")
       .from(`( ${subQueryBuilder.getQuery()} )`, "subQ")
       .setParameters(subQueryBuilder.getParameters());
 


### PR DESCRIPTION
## Description

This returns empty results (instead of 404) for lists that do not have contributors within certain filtered categories.

```json
{
  "data": [],
  "meta": {
    "page": 1,
    "limit": 10,
    "itemCount": 0,
    "pageCount": 0,
    "hasPreviousPage": false,
    "hasNextPage": false,
    "allContributionsCount": 0
  }
}
```

This also fixes an issue where there would be "null" returned for time-series chunks that don't have stats for a certain time frame. Now, `0` is returned instead.

```json
[
  {
    "commits": 0,
    "prs_created": 0,
    "time_start": "2023-09-11T16:01:59.857Z",
    "time_end": "2023-09-15T22:53:25.571Z"
  },
  {
    "commits": 0,
    "prs_created": 0,
    "time_start": "2023-09-15T22:53:25.571Z",
    "time_end": "2023-09-20T05:44:51.285Z"
  },
  {
    "commits": 0,
    "prs_created": 0,
    "time_start": "2023-09-20T05:44:51.285Z",
    "time_end": "2023-09-24T12:36:16.999Z"
  },
  {
    "commits": 0,
    "prs_created": 0,
    "time_start": "2023-09-24T12:36:16.999Z",
    "time_end": "2023-09-28T19:27:42.713Z"
  },
  {
    "commits": 0,
    "prs_created": 0,
    "time_start": "2023-09-28T19:27:42.714Z",
    "time_end": "2023-10-03T02:19:08.428Z"
  },
  {
    "commits": 0,
    "prs_created": 0,
    "time_start": "2023-10-03T02:19:08.428Z",
    "time_end": "2023-10-07T09:10:34.142Z"
  },
  {
    "commits": 0,
    "prs_created": 0,
    "time_start": "2023-10-07T09:10:34.142Z",
    "time_end": "2023-10-11T16:01:59.856Z"
  }
]
```

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

N/a related to user-lists release

## Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->


## Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 docs.opensauced.pizza
- [ ] 🍕 dev.to/opensauced
- [ ] 📕 storybook
- [ ] 🙅 no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?



## [optional] What gif best describes this PR or how it makes you feel?



<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
