### PR TITLE
fix: try/catch for posting to pizza service

### DIFF
--- a/src/insight/insight-repo.service.ts
+++ b/src/insight/insight-repo.service.ts
@@ -22,7 +22,13 @@ export class InsightRepoService {
       wait: false,
     };
 
-    await this.pizzaOvenService.postToPizzaOvenService(bakeRepoInfo);
+    try {
+      await this.pizzaOvenService.postToPizzaOvenService(bakeRepoInfo);
+    } catch (e: unknown) {
+      if (e instanceof Error) {
+        console.error(`error posting to pizza-oven service for repo ${bakeRepoInfo.url}: ${e.message}`);
+      }
+    }
 
     return this.insightRepoRepository.save({ insight_id: insightId, repo_id: repo.id, full_name: repo.fullName });
   }

--- a/src/insight/insights.service.ts
+++ b/src/insight/insights.service.ts
@@ -45,7 +45,13 @@ export class InsightsService {
         wait: false,
       };
 
-      await this.pizzaOvenService.postToPizzaOvenService(bakeRepoInfo);
+      try {
+        await this.pizzaOvenService.postToPizzaOvenService(bakeRepoInfo);
+      } catch (e: unknown) {
+        if (e instanceof Error) {
+          console.error(`error posting to pizza-oven service for repo ${bakeRepoInfo.url}: ${e.message}`);
+        }
+      }
     });
 
     return item;


### PR DESCRIPTION
## Description

This catches failures when posting repos to the pizza oven service. There is some validation that the pizza service does to ensure repos are actually git repos. And in some cases, they aren't (like with https://github.com/tamagui/sponsors)

This prevents unhandled errors from causing new insight pages to completely fail (as we saw in https://github.com/open-sauced/app/issues/2188)

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

Fixes: https://github.com/open-sauced/app/issues/2188

and partially related to: https://github.com/open-sauced/pizza/issues/61
## Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->

We can now sync the entire tamagui org without failure:

![Screenshot 2023-11-21 at 11 54 42 AM](https://github.com/open-sauced/api/assets/23109390/089b89da-0e9d-4420-b3b0-04287b12bda7)

## Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 docs.opensauced.pizza
- [ ] 🍕 dev.to/opensauced
- [ ] 📕 storybook
- [ ] 🙅 no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![](https://media.giphy.com/media/xUPGcB5L0TIfLrDH8c/giphy-downsized.gif)