### PR TITLE
feat: "get" for single workspace

### DIFF
--- a/src/workspace/workspace.controller.ts
+++ b/src/workspace/workspace.controller.ts
@@ -43,6 +43,21 @@ export class WorkspaceController {
     return this.workspaceService.findAllByUserId(pageOptionsDto, userId);
   }
 
+  @Get("/:id")
+  @ApiOperation({
+    operationId: "getWorkspaceByIdForUser",
+    summary: "Gets a workspace for the authenticated user",
+  })
+  @ApiBearerAuth()
+  @UseGuards(SupabaseGuard)
+  @ApiOkResponse({ type: DbWorkspace })
+  @ApiNotFoundResponse({ description: "Unable to get user workspace" })
+  @ApiBadRequestResponse({ description: "Invalid request" })
+  @ApiParam({ name: "id", type: "string" })
+  async getWorkspaceByIdForUser(@Param("id") id: string, @UserId() userId: number): Promise<DbWorkspace> {
+    return this.workspaceService.findOneByIdGuarded(id, userId);
+  }
+
   @Post("/")
   @ApiOperation({
     operationId: "createWorkspaceForUser",


### PR DESCRIPTION
## Description

This implements a "get" for a sole workspace:

<img width="576" alt="Screenshot 2024-01-12 at 8 11 27 AM" src="https://github.com/open-sauced/api/assets/23109390/09b5f713-79e3-472e-b0e3-325213261c5e">

## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents
Related to: https://github.com/open-sauced/engineering/issues/215
Related to: https://github.com/open-sauced/app/issues/2437

## Mobile & Desktop Screenshots/Recordings

## Steps to QA

1. Using route while authenticated:

```sh
curl -X 'GET' \
  'http://localhost:3003/v1/workspaces/248d7cbe-df52-442b-b1c1-a4304cf1c995' \
  -H 'accept: application/json' \
  -H 'Authorization: Bearer <redacted>'
```

yields the workspace json blob:

```json5
{
  "id": "248d7cbe-df52-442b-b1c1-a4304cf1c995",
  "created_at": "2024-01-05T23:23:51.003Z",
  "updated_at": "2024-01-05T23:23:51.003Z",
  "deleted_at": null,
  "name": "My Workspace",
  "description": "A workspace for my OSS collaborators",
  "members": [
    {
      "id": "d0ef702a-2588-4b3f-9daf-0d822cdd52c4",
      "user_id": 23109390,
      "workspace_id": "248d7cbe-df52-442b-b1c1-a4304cf1c995",
      "created_at": "2024-01-05T23:23:51.389Z",
      "updated_at": "2024-01-05T23:23:51.389Z",
      "deleted_at": null,
      "role": "owner"
    },
    // ... redacted
  ]
}
```

## Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 docs.opensauced.pizza
- [ ] 🍕 dev.to/opensauced
- [ ] 📕 storybook
- [ ] 🙅 no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?



## [optional] What gif best describes this PR or how it makes you feel?



<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
