### PR TITLE
fix: Removes activity ratio from repo entity

### DIFF
--- a/src/repo/entities/repo.entity.ts
+++ b/src/repo/entities/repo.entity.ts
@@ -552,16 +552,4 @@ export class DbRepo extends BaseEntity {
     insert: false,
   })
   public pr_active_count?: number;
-
-  @ApiModelProperty({
-    description: "Number of commits and comments over the number of unique contributors in time range",
-    example: 8.82,
-    type: "float",
-  })
-  @Column({
-    type: "float",
-    select: false,
-    insert: false,
-  })
-  public activity_ratio?: number;
 }

--- a/src/repo/repo.service.ts
+++ b/src/repo/repo.service.ts
@@ -179,8 +179,6 @@ export class RepoService {
         prevDaysStartDate
       );
 
-      const activityRatio = await this.repoDevstatsService.calculateRepoActivityRatio(entity.full_name, range);
-
       return {
         ...entity,
         pr_active_count: prStats.active_prs,
@@ -190,7 +188,6 @@ export class RepoService {
         draft_prs_count: prStats.draft_prs,
         closed_prs_count: prStats.closed_prs,
         pr_velocity_count: prStats.pr_velocity,
-        activity_ratio: activityRatio,
       } as DbRepo;
     });
 


### PR DESCRIPTION
## Description

This removes the unused activity ratio from the repo entity: this should help keep the `v2/repos/search` hot path from getting too bogged down

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

N/a - followup to #523 

## Mobile & Desktop Screenshots/Recordings

## Steps to QA

## Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 docs.opensauced.pizza
- [ ] 🍕 dev.to/opensauced
- [ ] 📕 storybook
- [ ] 🙅 no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?



## [optional] What gif best describes this PR or how it makes you feel?



<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
