### PR TITLE
feat: Add activity ratio back 

### DIFF
--- a/src/repo/entities/repo.entity.ts
+++ b/src/repo/entities/repo.entity.ts
@@ -552,4 +552,16 @@ export class DbRepo extends BaseEntity {
     insert: false,
   })
   public pr_active_count?: number;
+
+  @ApiModelProperty({
+    description: "Number of commits and comments over the number of unique contributors in time range",
+    example: 8.82,
+    type: "float",
+  })
+  @Column({
+    type: "float",
+    select: false,
+    insert: false,
+  })
+  public activity_ratio?: number;
 }

--- a/src/repo/entities/repo.entity.ts
+++ b/src/repo/entities/repo.entity.ts
@@ -564,4 +564,16 @@ export class DbRepo extends BaseEntity {
     insert: false,
   })
   public activity_ratio?: number;
+
+  @ApiModelProperty({
+    description: "Health is an aggregate, overview calculation of how a repo is generally doing",
+    example: 1.23,
+    type: "float",
+  })
+  @Column({
+    type: "float",
+    select: false,
+    insert: false,
+  })
+  public health?: number;
 }

--- a/src/repo/repo.service.ts
+++ b/src/repo/repo.service.ts
@@ -10,6 +10,7 @@ import { RepoFilterService } from "../common/filters/repo-filter.service";
 import { PageOptionsDto } from "../common/dtos/page-options.dto";
 import { GetPrevDateISOString } from "../common/util/datetimes";
 import { PullRequestGithubEventsService } from "../timescale/pull_request_github_events.service";
+import { RepoDevstatsService } from "../timescale/repo-devstats.service";
 import { RepoOrderFieldsEnum, RepoPageOptionsDto } from "./dtos/repo-page-options.dto";
 import { DbRepo } from "./entities/repo.entity";
 import { RepoSearchOptionsDto } from "./dtos/repo-search-options.dto";
@@ -21,7 +22,8 @@ export class RepoService {
     private repoRepository: Repository<DbRepo>,
     private filterService: RepoFilterService,
     @Inject(forwardRef(() => PullRequestGithubEventsService))
-    private pullRequestGithubEventsService: PullRequestGithubEventsService
+    private pullRequestGithubEventsService: PullRequestGithubEventsService,
+    private repoDevstatsService: RepoDevstatsService
   ) {}
 
   subQueryCount<T extends ObjectLiteral>(

--- a/src/repo/repo.service.ts
+++ b/src/repo/repo.service.ts
@@ -177,6 +177,8 @@ export class RepoService {
         prevDaysStartDate
       );
 
+      const activityRatio = await this.repoDevstatsService.calculateRepoActivityRatio(entity.full_name, range);
+
       return {
         ...entity,
         pr_active_count: prStats.active_prs,
@@ -186,6 +188,7 @@ export class RepoService {
         draft_prs_count: prStats.draft_prs,
         closed_prs_count: prStats.closed_prs,
         pr_velocity_count: prStats.pr_velocity,
+        activity_ratio: activityRatio,
       } as DbRepo;
     });
 

--- a/src/repo/repo.service.ts
+++ b/src/repo/repo.service.ts
@@ -191,6 +191,7 @@ export class RepoService {
         closed_prs_count: prStats.closed_prs,
         pr_velocity_count: prStats.pr_velocity,
         activity_ratio: activityRatio,
+        health: activityRatio,
       } as DbRepo;
     });
 

--- a/src/timescale/repo-devstats.service.ts
+++ b/src/timescale/repo-devstats.service.ts
@@ -23,7 +23,7 @@ export class RepoDevstatsService {
   ) {
     // defines quantile boundaries (ignore lower 5% and upper 95% percentiles)
     const lowerQ = 0.05;
-    const upperQ = 0.95;
+    const upperQ = 0.75;
 
     // calculate quantile values using the constant sampled activity ratios
     this.lowerBound = math.quantileSeq(avgRepoActivityRatioSample, lowerQ) as number;

--- a/src/workspace/entities/workspace-stats.entity.ts
+++ b/src/workspace/entities/workspace-stats.entity.ts
@@ -103,7 +103,20 @@ class DbWorkspaceRepoStats {
   forks = 0;
 
   @ApiModelProperty({
-    description: "Repository average health",
+    description:
+      "Number of commits and comments over the number of unique contributors in time range for entire workspace",
+    example: 9,
+    type: "integer",
+  })
+  @Column({
+    type: "integer",
+    select: false,
+    insert: false,
+  })
+  activity_ratio = 0;
+
+  @ApiModelProperty({
+    description: "An aggregate, overview calculation of how all repos in a workspace are generally doing",
     example: 9,
     type: "integer",
   })

--- a/src/workspace/workspace-stats.service.ts
+++ b/src/workspace/workspace-stats.service.ts
@@ -96,14 +96,17 @@ export class WorkspaceStatsService {
 
       result.repos.forks += entity.repo.forks;
       result.repos.stars += entity.repo.stars;
-      result.repos.health += activityRatio;
+      result.repos.activity_ratio += activityRatio;
     });
 
     await Promise.all(promises);
 
     result.pull_requests.velocity /= entities.length;
     result.issues.velocity /= entities.length;
-    result.repos.health /= entities.length;
+    result.repos.activity_ratio /= entities.length;
+
+    // activity ratio is currently the only stat that is used to inform health
+    result.repos.health = result.repos.activity_ratio;
 
     return result;
   }


### PR DESCRIPTION
## Description

This PR does a few things:
- Reverts https://github.com/open-sauced/api/pull/526 which removed activity ratios for individual repos when we were triaging an incident.
- Adds a separate "health" and "activity_ratio" since eventually these will be different: the "health" stats will be informed by many things, not just activity ratio. 
- Makes the upper quantile `upperQ` variable `0.75` which ignores more repos that are extreme outliers for activity among all repos on github.

## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

Related to: https://github.com/open-sauced/engineering/issues/246
and: https://github.com/open-sauced/api/issues/552

## Mobile & Desktop Screenshots/Recordings

N/a

## Steps to QA

1. Run API locally
2. Hit the repos/search endpoint
3. Notice the new `activity_ratio` field

```sh
curl -X 'GET' \
  'http://localhost:3003/v2/repos/search?page=1&limit=10&range=30&prev_days_start_date=0&repo=open-sauced%2Fapi' \
  -H 'accept: application/json'
```

```json5
{
  "data": [
    {
      "id": 499330806,
      // ...
      "activity_ratio": 3.8119234662113306
      "health": 3.8119234662113306
    }
  ],
  "meta": {
    "page": 1,
    "limit": 10,
    "itemCount": 0,
    "pageCount": 0,
    "hasPreviousPage": false,
    "hasNextPage": false
  }
}
```

---

I did a few experiments to see how this new activity ratio (with more outliers removed) compares:

### Before

| Repo | Activity ratio |
|--------|--------|
| open-sauced/app | 4.450073874502307 |
| open-sauced/api | 1.0078263530698686 |
| documenso/documenso | 1.7285550956932512 |
| formbricks/formbricks | 2.486382039760193 |
| appwrite/appwrite | 10 |
| maybe-finance/maybe | 10 |
| kubernetes/kubernetes (an obvious upper bound outlier) | 10 | 
| sindresorhus/awesome (no push activity in last few months) | 0 | 

### After

| Repo | Activity ratio |
|--------|--------|
| open-sauced/app | 10 |
| open-sauced/api | 3.8119234662113306 |
| documenso/documenso | 6.537951415778744 |
| formbricks/formbricks | 9.404296697003723 |
| appwrite/appwrite | 10 |
| maybe-finance/maybe | 10 |
| kubernetes/kubernetes (an obvious upper bound outlier) | 10 | 
| sindresorhus/awesome (no push activity in last few months) | 0 | 

## Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 docs.opensauced.pizza
- [ ] 🍕 dev.to/opensauced
- [ ] 📕 storybook
- [ ] 🙅 no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
