### PR TITLE
feat: Add http cache headers

### DIFF
--- a/src/repo/repo.controller.ts
+++ b/src/repo/repo.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Param, ParseIntPipe, Query } from "@nestjs/common";
+import { Controller, Get, Header, Param, ParseIntPipe, Query } from "@nestjs/common";
 import { ApiNotFoundResponse, ApiOkResponse, ApiOperation, ApiParam, ApiTags } from "@nestjs/swagger";
 import { PageDto } from "../common/dtos/page.dto";
 import { ApiPaginatedResponse } from "../common/decorators/api-paginated-response.decorator";
@@ -23,6 +23,7 @@ export class RepoController {
   @ApiOkResponse({ type: DbRepo })
   @ApiNotFoundResponse({ description: "Repository not found" })
   @ApiParam({ name: "id", type: "integer" })
+  @Header("Cache-Control", "public, max-age=600")
   async findOneById(@Param("id", ParseIntPipe) id: number): Promise<DbRepo> {
     return this.repoService.findOneById(id);
   }
@@ -34,6 +35,7 @@ export class RepoController {
   })
   @ApiOkResponse({ type: DbRepo })
   @ApiNotFoundResponse({ description: "Repository not found" })
+  @Header("Cache-Control", "public, max-age=600")
   async findOneByOwnerAndRepo(@Param("owner") owner: string, @Param("repo") repo: string): Promise<DbRepo> {
     return this.repoService.findOneByOwnerAndRepo(owner, repo);
   }
@@ -46,6 +48,7 @@ export class RepoController {
   @ApiPaginatedResponse(DbRepoContributor)
   @ApiOkResponse({ type: DbRepoContributor })
   @ApiNotFoundResponse({ description: "Repository not found" })
+  @Header("Cache-Control", "public, max-age=600")
   async findContributorsByOwnerAndRepo(
     @Param("owner") owner: string,
     @Param("repo") repo: string,
@@ -61,6 +64,7 @@ export class RepoController {
   })
   @ApiPaginatedResponse(DbRepo)
   @ApiOkResponse({ type: DbRepo })
+  @Header("Cache-Control", "public, max-age=600")
   async findAll(@Query() pageOptionsDto: RepoPageOptionsDto): Promise<PageDto<DbRepo>> {
     return this.repoService.findAll(pageOptionsDto);
   }
@@ -72,6 +76,7 @@ export class RepoController {
   })
   @ApiPaginatedResponse(DbRepo)
   @ApiOkResponse({ type: DbRepo })
+  @Header("Cache-Control", "public, max-age=600")
   async findAllReposWithFilters(@Query() pageOptionsDto: RepoSearchOptionsDto): Promise<PageDto<DbRepo>> {
     return this.repoService.findAllWithFilters(pageOptionsDto);
   }

--- a/src/user-lists/user-list-stats.controller.ts
+++ b/src/user-lists/user-list-stats.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Param, Query } from "@nestjs/common";
+import { Controller, Get, Header, Param, Query } from "@nestjs/common";
 import {
   ApiOperation,
   ApiOkResponse,
@@ -37,6 +37,7 @@ export class UserListStatsController {
   @ApiNotFoundResponse({ description: "Unable to get list most active contributors" })
   @ApiBadRequestResponse({ description: "Invalid request" })
   @ApiParam({ name: "id", type: "string" })
+  @Header("Cache-Control", "private, max-age=600")
   async getMostActiveContributorsV2(
     @Param("id") id: string,
     @Query() pageOptionsDto: UserListMostActiveContributorsDto
@@ -53,6 +54,7 @@ export class UserListStatsController {
   @ApiNotFoundResponse({ description: "Unable to get contributions" })
   @ApiBadRequestResponse({ description: "Invalid request" })
   @ApiParam({ name: "id", type: "string" })
+  @Header("Cache-Control", "private, max-age=600")
   async getContributionsByTimeFrame(
     @Param("id") id: string,
     @Query() options: ContributionsTimeframeDto
@@ -70,6 +72,7 @@ export class UserListStatsController {
   @ApiBadRequestResponse({ description: "Invalid request" })
   @ApiParam({ name: "id", type: "string" })
   @ApiQuery({ name: "range", type: "integer", required: false })
+  @Header("Cache-Control", "private, max-age=600")
   async getContributionsByProject(
     @Param("id") id: string,
     @Query() options: ContributionsByProjectDto
@@ -86,6 +89,7 @@ export class UserListStatsController {
   @ApiNotFoundResponse({ description: "Unable to get contributions" })
   @ApiBadRequestResponse({ description: "Invalid request" })
   @ApiParam({ name: "id", type: "string" })
+  @Header("Cache-Control", "private, max-age=600")
   async getContributorContributionsByProject(
     @Param("id") id: string,
     @Query() options: TopProjectsDto
@@ -102,6 +106,7 @@ export class UserListStatsController {
   @ApiNotFoundResponse({ description: "Unable to get contributions" })
   @ApiBadRequestResponse({ description: "Invalid request" })
   @ApiParam({ name: "id", type: "string" })
+  @Header("Cache-Control", "private, max-age=600")
   async getContributionsByTimeframe(
     @Param("id") id: string,
     @Query() options: ContributionsTimeframeDto

--- a/src/user-lists/user-list.controller.ts
+++ b/src/user-lists/user-list.controller.ts
@@ -1,4 +1,16 @@
-import { Body, Controller, Delete, Get, Param, Patch, Post, Query, UseGuards, ValidationPipe } from "@nestjs/common";
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Header,
+  Param,
+  Patch,
+  Post,
+  Query,
+  UseGuards,
+  ValidationPipe,
+} from "@nestjs/common";
 import {
   ApiOperation,
   ApiOkResponse,
@@ -56,6 +68,7 @@ export class UserListController {
     summary: "Gets public featured lists",
   })
   @ApiOkResponse({ type: DbUserList })
+  @Header("Cache-Control", "public, max-age=600")
   async getFeaturedLists(@Query() pageOptionsDto: PageOptionsDto): Promise<PageDto<DbUserList>> {
     return this.userListService.findAllFeatured(pageOptionsDto);
   }

--- a/src/user/user-collaboration.controller.ts
+++ b/src/user/user-collaboration.controller.ts
@@ -4,6 +4,7 @@ import {
   Controller,
   Delete,
   Get,
+  Header,
   Param,
   Patch,
   Post,
@@ -52,6 +53,7 @@ export class UserCollaborationController {
   @UseGuards(SupabaseGuard)
   @ApiPaginatedResponse(DbUserCollaboration)
   @ApiOkResponse({ type: DbUserCollaboration })
+  @Header("Cache-Control", "private, max-age=600")
   async findAllUserCollaborations(
     @Query() pageOptionsDto: PageOptionsDto,
     @UserId() userId: number

--- a/src/user/user-highlight.controller.ts
+++ b/src/user/user-highlight.controller.ts
@@ -4,6 +4,7 @@ import {
   Controller,
   Delete,
   Get,
+  Header,
   Param,
   ParseIntPipe,
   Patch,
@@ -66,6 +67,7 @@ export class UserHighlightsController {
   @ApiNotFoundResponse({ description: "Unable to get user highlight" })
   @ApiBadRequestResponse({ description: "Invalid request" })
   @ApiParam({ name: "id", type: "integer" })
+  @Header("Cache-Control", "public, max-age=600")
   async getUserHighlight(@Param("id", ParseIntPipe) id: number): Promise<DbUserHighlight> {
     return this.userHighlightsService.findOneById(id);
   }
@@ -131,6 +133,7 @@ export class UserHighlightsController {
   @ApiNotFoundResponse({ description: "Unable to get user highlight reactions" })
   @ApiBadRequestResponse({ description: "Invalid request" })
   @ApiParam({ name: "id", type: "integer" })
+  @Header("Cache-Control", "private, max-age=600")
   async getAllHighlightUserReactions(
     @Param("id", ParseIntPipe) id: number,
     @UserId() userId: number
@@ -196,6 +199,7 @@ export class UserHighlightsController {
   @ApiBearerAuth()
   @UseGuards(SupabaseGuard)
   @ApiOkResponse({ type: DbUserHighlight })
+  @Header("Cache-Control", "private, max-age=600")
   async getFollowingHighlights(
     @Query() pageOptionsDto: HighlightOptionsDto,
     @UserId() userId: number
@@ -212,6 +216,7 @@ export class UserHighlightsController {
   @UseGuards(SupabaseGuard)
   @ApiOkResponse({ type: DbUserHighlightRepo })
   @ApiBadRequestResponse({ description: "Invalid request" })
+  @Header("Cache-Control", "private, max-age=600")
   async getFollowingHighlightRepos(
     @Query() pageOptionsDto: HighlightOptionsDto,
     @UserId() userId: number

--- a/src/user/user-recommendation.controller.ts
+++ b/src/user/user-recommendation.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Query, UseGuards } from "@nestjs/common";
+import { Controller, Get, Header, Query, UseGuards } from "@nestjs/common";
 import { ApiOperation, ApiBearerAuth, ApiTags, ApiOkResponse } from "@nestjs/swagger";
 
 import { SupabaseGuard } from "../auth/supabase.guard";
@@ -24,6 +24,7 @@ export class UserRecommendationController {
   @ApiPaginatedResponse(DbRepo)
   @ApiOkResponse({ type: DbRepo })
   @UseGuards(SupabaseGuard)
+  @Header("Cache-Control", "private, max-age=600")
   async findUserRepoRecommendations(@UserId() userId: number) {
     const user = await this.userService.findOneById(userId);
     const interests = user.interests?.split(",").filter(Boolean) ?? [];
@@ -40,6 +41,7 @@ export class UserRecommendationController {
   @ApiPaginatedResponse(DbRepo)
   @ApiOkResponse({ type: DbRepo })
   @UseGuards(SupabaseGuard)
+  @Header("Cache-Control", "private, max-age=600")
   async findUserOrgsRepoRecommendations(@UserId() userId: number, @Query() pageOptionsDto: PageOptionsDto) {
     return this.repoService.findOrgsRecommendations(userId, pageOptionsDto);
   }

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Param, Query } from "@nestjs/common";
+import { Controller, Get, Header, Param, Query } from "@nestjs/common";
 import { ApiBadRequestResponse, ApiNotFoundResponse, ApiOkResponse, ApiOperation, ApiTags } from "@nestjs/swagger";
 
 import { PageOptionsDto } from "../common/dtos/page-options.dto";
@@ -49,6 +49,7 @@ export class UserController {
   @ApiPaginatedResponse(DbPullRequestGitHubEvents)
   @ApiOkResponse({ type: DbPullRequestGitHubEvents })
   @ApiNotFoundResponse({ description: "User not found" })
+  @Header("Cache-Control", "public, max-age=600")
   async findContributorPullRequestGitHubEvents(
     @Param("username") username: string,
     @Query() pageOptionsDto: PageOptionsDto
@@ -64,6 +65,7 @@ export class UserController {
   @ApiPaginatedResponse(DbUserHighlight)
   @ApiOkResponse({ type: DbUserHighlight })
   @ApiNotFoundResponse({ description: "Highlights not found" })
+  @Header("Cache-Control", "public, max-age=600")
   async findAllHighlightsByUsername(
     @Param("username") username: string,
     @Query() pageOptionsDto: PageOptionsDto
@@ -81,6 +83,7 @@ export class UserController {
   @ApiPaginatedResponse(DbRepo)
   @ApiOkResponse({ type: DbRepo })
   @ApiNotFoundResponse({ description: "Top repos not found" })
+  @Header("Cache-Control", "public, max-age=600")
   async findAllTopReposByUsername(
     @Param("username") username: string,
     @Query() pageOptionsDto: PageOptionsDto
@@ -98,6 +101,7 @@ export class UserController {
   @ApiPaginatedResponse(DbUserOrganization)
   @ApiOkResponse({ type: DbUserOrganization })
   @ApiNotFoundResponse({ description: "Top repos not found" })
+  @Header("Cache-Control", "public, max-age=600")
   async findAllOrgsByUsername(
     @Param("username") username: string,
     @Query() pageOptionsDto: PageOptionsDto
@@ -113,6 +117,7 @@ export class UserController {
     summary: "List top users",
   })
   @ApiOkResponse({ type: DbTopUser })
+  @Header("Cache-Control", "public, max-age=600")
   async getTopUsers(@Query() pageOptionsDto: TopUsersDto): Promise<PageDto<DbTopUser>> {
     return this.userService.findTopUsers(pageOptionsDto);
   }

--- a/src/workspace/workspace-stats.controller.ts
+++ b/src/workspace/workspace-stats.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Param, Query, UseGuards } from "@nestjs/common";
+import { Controller, Get, Header, Param, Query, UseGuards } from "@nestjs/common";
 import {
   ApiOperation,
   ApiOkResponse,
@@ -32,6 +32,7 @@ export class WorkspaceStatsController {
   @ApiNotFoundResponse({ description: "Unable to get user workspace stats" })
   @ApiBadRequestResponse({ description: "Invalid request" })
   @ApiParam({ name: "id", type: "string" })
+  @Header("Cache-Control", "private, max-age=600")
   async getWorkspaceStatsForUser(
     @Param("id") id: string,
     @UserId() userId: number,


### PR DESCRIPTION
## Description

Adds http cache headers for routes that make sense. Primarily, on the user-list routes for the metrics is where it makes the most sense in order to not throttle the timescale database.

## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

Closes: https://github.com/open-sauced/api/issues/566

## Mobile & Desktop Screenshots/Recordings

## Steps to QA

1. Run API locally
2. Hit one of the modified endpoints
3. See http cache header:
 
![Screenshot 2024-02-19 at 3 17 29 PM](https://github.com/open-sauced/api/assets/23109390/30dffe7b-4fa5-4b40-a843-d993fd1b8986)

## Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 docs.opensauced.pizza
- [ ] 🍕 dev.to/opensauced
- [ ] 📕 storybook
- [ ] 🙅 no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?



## [optional] What gif best describes this PR or how it makes you feel?



<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
