### PR TITLE
feat: Implements ross index/contributors

### DIFF
--- a/src/timescale/common/repos.spec.ts
+++ b/src/timescale/common/repos.spec.ts
@@ -1,0 +1,46 @@
+import { sanatizeRepos } from "./repos";
+
+describe("sanatizeRepos", () => {
+  test("should conform to 'LOWER' strings for db query indexes", () => {
+    const input = ["Org/Repo"];
+    const output = sanatizeRepos(input);
+
+    expect(output).toEqual(["org/repo"]);
+  });
+
+  test("should remove empty strings", () => {
+    const input = ["Org/Repo", ""];
+    const output = sanatizeRepos(input);
+
+    expect(output).toHaveLength(1);
+    expect(output).toEqual(["org/repo"]);
+  });
+
+  test("should filter out strings not in the format {org}/{name}", () => {
+    const input = ["Org/Repo", "JustName", "org/"];
+    const output = sanatizeRepos(input);
+
+    expect(output).toEqual(["org/repo"]);
+  });
+
+  test("should handle strings with multiple slashes", () => {
+    const input = ["Org/Repo/Extra", "org/repo"];
+    const output = sanatizeRepos(input);
+
+    expect(output).toEqual(["org/repo"]);
+  });
+
+  test("should work with multiple valid inputs", () => {
+    const input = ["Org1/Repo1", "Org2/Repo2"];
+    const output = sanatizeRepos(input);
+
+    expect(output).toEqual(["org1/repo1", "org2/repo2"]);
+  });
+
+  test("should return an empty array for all invalid inputs", () => {
+    const input = ["", "/", "Invalid"];
+    const output = sanatizeRepos(input);
+
+    expect(output).toEqual([]);
+  });
+});

--- a/src/timescale/common/repos.ts
+++ b/src/timescale/common/repos.ts
@@ -1,0 +1,14 @@
+/*
+ * the following is a convenience function that:
+ *   - validates via regex that the repos are of the for "{repo-owner}/{repo-name}"
+ *   - ensures there are no hanging spaces
+ *   - ensures there are no empty repo names.
+ *
+ *  this is in service of optimizing for "LOWER(repo_name)" queries against timescale
+ */
+
+export const sanatizeRepos = (repos: string[]): string[] => {
+  const validRepoRegex = /^[^/]+\/[^/]+$/;
+
+  return repos.map((repo) => repo.toLowerCase()).filter((repo) => repo && validRepoRegex.test(repo));
+};

--- a/src/timescale/entities/ross_index_histogram.ts
+++ b/src/timescale/entities/ross_index_histogram.ts
@@ -1,0 +1,81 @@
+import { ApiModelProperty } from "@nestjs/swagger/dist/decorators/api-model-property.decorator";
+import { Column, Entity } from "typeorm";
+
+@Entity("workspaces")
+export class DbRossIndexHistogram {
+  @ApiModelProperty({
+    description: "Timestamp representing histogram bucket day",
+    example: "2022-08-28 22:04:29.000000",
+  })
+  @Column({
+    type: "timestamp without time zone",
+    select: false,
+    insert: false,
+  })
+  public bucket: Date;
+
+  @ApiModelProperty({
+    description: "Ross index for given time period",
+    example: 4,
+    type: "integer",
+  })
+  @Column({
+    type: "integer",
+    select: false,
+    insert: false,
+  })
+  public index: number;
+}
+
+@Entity("workspaces")
+export class DbRossContributorsHistogram {
+  @ApiModelProperty({
+    description: "Timestamp representing histogram bucket day",
+    example: "2022-08-28 22:04:29.000000",
+  })
+  @Column({
+    type: "timestamp without time zone",
+    select: false,
+    insert: false,
+  })
+  public bucket: Date;
+
+  @ApiModelProperty({
+    description:
+      "Number of new contributors within time range. These are contributors whose affiliation to a repo is 'NONE'.",
+    example: 4,
+    type: "integer",
+  })
+  @Column({
+    type: "integer",
+    select: false,
+    insert: false,
+  })
+  public new: number;
+
+  @ApiModelProperty({
+    description:
+      "Number of returning contributors within time range. These are contributors whose affiliation to a repo is 'CONTRIBUTOR'.",
+    example: 4,
+    type: "integer",
+  })
+  @Column({
+    type: "integer",
+    select: false,
+    insert: false,
+  })
+  public returning: number;
+
+  @ApiModelProperty({
+    description:
+      "Number of internal contributors within time range. These are contributors whose affiliation to a repo is 'MEMBER' - i.e., org members.",
+    example: 4,
+    type: "integer",
+  })
+  @Column({
+    type: "integer",
+    select: false,
+    insert: false,
+  })
+  public internal: number;
+}

--- a/src/workspace/entities/workspace-ross.entity.ts
+++ b/src/workspace/entities/workspace-ross.entity.ts
@@ -1,0 +1,25 @@
+import { ApiModelProperty } from "@nestjs/swagger/dist/decorators/api-model-property.decorator";
+import { Entity, Column } from "typeorm";
+import { DbRossContributorsHistogram, DbRossIndexHistogram } from "../../timescale/entities/ross_index_histogram";
+
+@Entity("workspaces")
+export class DbWorkspaceRossIndex {
+  @ApiModelProperty({
+    description: "Histogram buckets for the ross index of a workspace repos over a period of time",
+  })
+  @Column({
+    select: false,
+    insert: false,
+  })
+  ross: DbRossIndexHistogram[];
+
+  @ApiModelProperty({
+    description:
+      "Histogram buckets for the new/returning/internal contributors of tracked workspace repos over a period of time",
+  })
+  @Column({
+    select: false,
+    insert: false,
+  })
+  contributors: DbRossContributorsHistogram[];
+}

--- a/src/workspace/workspace-stats.controller.ts
+++ b/src/workspace/workspace-stats.controller.ts
@@ -15,6 +15,7 @@ import { OptionalUserId } from "../auth/supabase.user.decorator";
 import { DbWorkspaceStats } from "./entities/workspace-stats.entity";
 import { WorkspaceStatsService } from "./workspace-stats.service";
 import { WorkspaceStatsOptionsDto } from "./dtos/workspace-stats.dto";
+import { DbWorkspaceRossIndex } from "./entities/workspace-ross.entity";
 
 @Controller("workspaces/:id")
 @ApiTags("Workspaces stats service")
@@ -39,5 +40,25 @@ export class WorkspaceStatsController {
     @Query() workspaceStatsOptionsDto: WorkspaceStatsOptionsDto
   ): Promise<DbWorkspaceStats> {
     return this.workspaceStatsService.findStatsByWorkspaceIdForUserId(workspaceStatsOptionsDto, id, userId);
+  }
+
+  @Get("/ross")
+  @ApiOperation({
+    operationId: "getWorkspaceRossIndex",
+    summary: "Gets workspace ross index/stats for the authenticated user",
+  })
+  @ApiBearerAuth()
+  @UseGuards(PassthroughSupabaseGuard)
+  @ApiOkResponse({ type: DbWorkspaceStats })
+  @ApiNotFoundResponse({ description: "Unable to get user workspace ross index" })
+  @ApiBadRequestResponse({ description: "Invalid request" })
+  @ApiParam({ name: "id", type: "string" })
+  @Header("Cache-Control", "private, max-age=600")
+  async getWorkspaceRossIndex(
+    @Param("id") id: string,
+    @OptionalUserId() userId: number | undefined,
+    @Query() workspaceStatsOptionsDto: WorkspaceStatsOptionsDto
+  ): Promise<DbWorkspaceRossIndex> {
+    return this.workspaceStatsService.findRossByWorkspaceIdForUserId(workspaceStatsOptionsDto, id, userId);
   }
 }


### PR DESCRIPTION
## Description

Implements a workspaces route that returns data for the workspace repos and their ross index over time (in 1 week increments) and the number of new/recurring/internal contributors within those same time frames.

In the future, we can use both `findRossContributorsByRepos` and `findRossIndexByRepos` on individual repos to get more fine grained stats on those sole repos. 

Note: this is widely based on explorations by @bdougie in https://github.com/open-sauced/engineering/issues/37 and will enable the internal/external contributors timeseries as visualized in https://github.com/open-sauced/api/issues/585

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

Closes: https://github.com/open-sauced/api/issues/585

## Mobile & Desktop Screenshots/Recordings

## Steps to QA

1. Create a workspace with some tracked repos
2. Hit this endpoint via the api like:

```sh
$ curl -X 'GET' \
  'http://localhost:3003/v2/workspaces/8d9f8ee1-b5dc-452c-b547-6cd2e375f1ec/ross?range=30&prev_days_start_date=0' \
  -H 'accept: application/json' \
  -H 'Authorization: Bearer <redacted>'
```

and get data back like:

```json
{
  "ross": [
    {
      "bucket": "2024-02-19T00:00:00.000Z",
      "index": 0.012658227848101266
    },
    {
      "bucket": "2024-02-05T00:00:00.000Z",
      "index": 0.051470588235294115
    },
    {
      "bucket": "2024-01-29T00:00:00.000Z",
      "index": 0.0028735632183908046
    },
    {
      "bucket": "2024-01-22T00:00:00.000Z",
      "index": 0.04950495049504951
    }
  ],
  "contributors": [
    {
      "bucket": "2024-02-19T00:00:00.000Z",
      "new": 1,
      "recurring": 9,
      "internal": 9
    },
    {
      "bucket": "2024-02-05T00:00:00.000Z",
      "new": 7,
      "recurring": 17,
      "internal": 21
    },
    {
      "bucket": "2024-01-29T00:00:00.000Z",
      "new": 1,
      "recurring": 9,
      "internal": 15
    },
    {
      "bucket": "2024-01-22T00:00:00.000Z",
      "new": 5,
      "recurring": 12,
      "internal": 16
    }
  ]
}
```

Note ^ this was data from one of my workspaces with a few kubernetes projects in there.

## Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 docs.opensauced.pizza
- [ ] 🍕 dev.to/opensauced
- [ ] 📕 storybook
- [ ] 🙅 no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?



## [optional] What gif best describes this PR or how it makes you feel?



<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
