### PR TITLE
fix: Add parsing of boolean strings

### DIFF
--- a/src/timescale/pull_request_github_events.service.ts
+++ b/src/timescale/pull_request_github_events.service.ts
@@ -232,13 +232,17 @@ export class PullRequestGithubEventsService {
       .select("*");
 
     if (pageOptionsDto.distinctAuthors) {
-      cteBuilder.addSelect(
-        `ROW_NUMBER() OVER (PARTITION BY pr_author_login, repo_name ORDER BY event_time ${order}) AS row_num`
-      );
-    } else {
-      cteBuilder.addSelect(
-        `ROW_NUMBER() OVER (PARTITION BY pr_number, repo_name ORDER BY event_time ${order}) AS row_num`
-      );
+      const distinctAuthors = pageOptionsDto.distinctAuthors === "true" || pageOptionsDto.distinctAuthors === "1";
+
+      if (distinctAuthors) {
+        cteBuilder.addSelect(
+          `ROW_NUMBER() OVER (PARTITION BY pr_author_login, repo_name ORDER BY event_time ${order}) AS row_num`
+        );
+      } else {
+        cteBuilder.addSelect(
+          `ROW_NUMBER() OVER (PARTITION BY pr_number, repo_name ORDER BY event_time ${order}) AS row_num`
+        );
+      }
     }
 
     cteBuilder

--- a/src/workspace/dtos/update-workspace.dto.ts
+++ b/src/workspace/dtos/update-workspace.dto.ts
@@ -1,5 +1,5 @@
-import { ApiProperty } from "@nestjs/swagger";
-import { IsBooleanString, IsString } from "class-validator";
+import { ApiProperty, ApiPropertyOptional } from "@nestjs/swagger";
+import { IsBooleanString, IsOptional, IsString } from "class-validator";
 
 export class UpdateWorkspaceDto {
   @ApiProperty({
@@ -18,11 +18,12 @@ export class UpdateWorkspaceDto {
   @IsString()
   description: string;
 
-  @ApiProperty({
+  @ApiPropertyOptional({
     description: "A boolean to make the workspace public: the authenticated user must be a paid customer",
     type: String,
-    example: false,
+    example: "true",
   })
+  @IsOptional()
   @IsBooleanString()
-  is_public: string;
+  is_public?: string;
 }

--- a/src/workspace/workspace.service.ts
+++ b/src/workspace/workspace.service.ts
@@ -256,8 +256,16 @@ export class WorkspaceService {
       throw new UnauthorizedException();
     }
 
-    if (!dto.is_public && !workspace.payee_user_id) {
-      throw new BadRequestException("workspace has no payee: cannot make private");
+    if (dto.is_public) {
+      const isPublic = dto.is_public === "true" || dto.is_public === "1";
+
+      if (!isPublic && !workspace.payee_user_id) {
+        throw new BadRequestException("workspace has no payee: cannot make private");
+      }
+
+      await this.workspaceRepository.update(id, {
+        is_public: isPublic,
+      });
     }
 
     await this.workspaceRepository.update(id, {


### PR DESCRIPTION
## Description

This fixes the use of `IsBooleanString` in a few spots:
- Workspace update dto now accepts an optional `is_public` and that boolean gets interpreted dynamically to update the workspace
- The `distinctAuthors` pull request event bool is now interpreted correctly

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

N/a - follow up to: https://github.com/open-sauced/api/pull/576 and https://github.com/open-sauced/app/issues/2727

## Mobile & Desktop Screenshots/Recordings

## Steps to QA

Able to patch a workspace with an optional `is_public` flag:

```sh
❯ curl -X 'PATCH' \
  'http://localhost:3003/v2/workspaces/8d9f8ee1-b5dc-452c-b547-6cd2e375f1ec' \
  -H 'accept: application/json' \
  -H 'Authorization: Bearer <redacted>' \
  -H 'Content-Type: application/json' \
  -d '{
  "name": "My personal woof workspace",
  "description": "A workspace for my personal OSS collaborators"
}'
```

```json
{"id":"8d9f8ee1-b5dc-452c-b547-6cd2e375f1ec","created_at":"2024-02-15T04:51:48.907Z","updated_at":"2024-02-22T22:28:18.512Z","deleted_at":null,"name":"My personal woof workspace","description":"A workspace for my personal OSS collaborators","is_public":true,"payee_user_id":null,"members":[{"id":"8efb6b2a-957e-4d58-8470-2a6f141d8e02","user_id":23109390,"workspace_id":"8d9f8ee1-b5dc-452c-b547-6cd2e375f1ec","created_at":"2024-02-15T04:51:48.907Z","updated_at":"2024-02-15T04:51:48.907Z","deleted_at":null,"role":"owner"}]}
```


## Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 docs.opensauced.pizza
- [ ] 🍕 dev.to/opensauced
- [ ] 📕 storybook
- [ ] 🙅 no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?



## [optional] What gif best describes this PR or how it makes you feel?



<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
