### PR TITLE
chore: create auto-add-to-project.yml to auto add opened issues to the team dashboard

### DIFF
--- a/.github/workflows/auto-add-to-project.yml
+++ b/.github/workflows/auto-add-to-project.yml
@@ -1,0 +1,24 @@
+name: Adds all issues opened in the /api repo to the Team Dashboard
+
+on:
+  issues:
+    types:
+      - opened
+
+jobs:
+  add-to-project:
+    name: Add issue to project
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate token
+        id: generate_token
+        uses: tibdex/github-app-token@v1
+        with:
+          app_id: ${{ secrets.OS_GITHUB_APP_ID }}
+          private_key: ${{ secrets.OS_GITHUB_APP_PRIVATE_KEY }}
+    
+      - name: add issue to team dashboard
+        uses: actions/add-to-project@RELEASE_VERSION
+        with:
+          project-url: https://github.com/orgs/open-sauced/projects/25
+          github-token: ${{ steps.generate_token.outputs.token }}

--- a/.github/workflows/auto-add-to-project.yml
+++ b/.github/workflows/auto-add-to-project.yml
@@ -18,7 +18,7 @@ jobs:
           private_key: ${{ secrets.OS_GITHUB_APP_PRIVATE_KEY }}
     
       - name: add issue to team dashboard
-        uses: actions/add-to-project
+        uses: actions/add-to-project@v0.5.0
         with:
           project-url: https://github.com/orgs/open-sauced/projects/25
           github-token: ${{ steps.generate_token.outputs.token }}

--- a/.github/workflows/auto-add-to-project.yml
+++ b/.github/workflows/auto-add-to-project.yml
@@ -18,7 +18,7 @@ jobs:
           private_key: ${{ secrets.OS_GITHUB_APP_PRIVATE_KEY }}
     
       - name: add issue to team dashboard
-        uses: actions/add-to-project@RELEASE_VERSION
+        uses: actions/add-to-project
         with:
           project-url: https://github.com/orgs/open-sauced/projects/25
           github-token: ${{ steps.generate_token.outputs.token }}


### PR DESCRIPTION
## Description

This PR adds a github action that auto-adds issues opened in the /api repo to the [Team Dashboard](https://github.com/orgs/open-sauced/projects/25)

## What type of PR is this? (check all applicable)

- [X] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents
-
## Mobile & Desktop Screenshots/Recordings
-


## Steps to QA
-


## Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 docs.opensauced.pizza
- [ ] 🍕 dev.to/opensauced
- [ ] 📕 storybook
- [ X] 🙅 no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?
-

## [optional] What gif best describes this PR or how it makes you feel?
-
