### PR TITLE
fix: use workspace-repo service for `findOneById`

### DIFF
--- a/src/workspace/workspace-user-lists.service.ts
+++ b/src/workspace/workspace-user-lists.service.ts
@@ -313,7 +313,7 @@ export class WorkspaceUserListsService {
       name: dto.name,
     });
 
-    return this.userListService.findOneById(userList.id, userId);
+    return this.findOneUserListByWorkspaceIdForUserIdUnguarded(id, userListId);
   }
 
   async deleteWorkspaceUserList(id: string, userListId: string, userId: number) {


### PR DESCRIPTION
## Description

Real quick followup to: #635 which refactored access control to workspace insight pages. This removes the last hanging `findOneById` from the list service which didn't encompass our newer workspace auth correctly.

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

Followup: #635 

## Mobile & Desktop Screenshots/Recordings

## Steps to QA

## Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 docs.opensauced.pizza
- [ ] 🍕 dev.to/opensauced
- [ ] 📕 storybook
- [ ] 🙅 no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?



## [optional] What gif best describes this PR or how it makes you feel?

![](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExMDdyeXk0YWMzc3I1NzN3MjJ3d2FhdWQ1a2UwaHhuNGQ3eW44ZnNibCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/dmvodzjX8wU7icE3TL/giphy.gif)

<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
