### PR TITLE
chore: Refactors workspace list-service `findOneUserList...` function name

### DIFF
--- a/src/workspace/workspace-user-lists.service.ts
+++ b/src/workspace/workspace-user-lists.service.ts
@@ -67,7 +67,7 @@ export class WorkspaceUserListsService {
     return new PageDto(entities, pageMetaDto);
   }
 
-  private async findOneUserListByWorkspaceIdForUserIdUnguarded(id: string, userListId: string): Promise<DbUserList> {
+  private async findOneUserListByWorkspaceIdListIdUnguarded(id: string, userListId: string): Promise<DbUserList> {
     const userList: DbUserList | undefined = await this.baseQueryBuilder()
       .leftJoinAndSelect("workspace_user_lists.user_list", "workspace_user_lists_user_list")
       .leftJoinAndSelect(
@@ -104,7 +104,7 @@ export class WorkspaceUserListsService {
       throw new NotFoundException();
     }
 
-    return this.findOneUserListByWorkspaceIdForUserIdUnguarded(id, userListId);
+    return this.findOneUserListByWorkspaceIdListIdUnguarded(id, userListId);
   }
 
   async findWorkspaceUserListContributors(
@@ -125,7 +125,7 @@ export class WorkspaceUserListsService {
       throw new NotFoundException();
     }
 
-    const userList = await this.findOneUserListByWorkspaceIdForUserIdUnguarded(id, userListId);
+    const userList = await this.findOneUserListByWorkspaceIdListIdUnguarded(id, userListId);
 
     return this.userListService.findContributorsByListId(pageOptionsDto, userList.id);
   }
@@ -148,7 +148,7 @@ export class WorkspaceUserListsService {
       throw new NotFoundException();
     }
 
-    const userList = await this.findOneUserListByWorkspaceIdForUserIdUnguarded(id, userListId);
+    const userList = await this.findOneUserListByWorkspaceIdListIdUnguarded(id, userListId);
 
     return this.userListService.findListContributorsHighlights(pageOptionsDto, userList.id);
   }
@@ -171,7 +171,7 @@ export class WorkspaceUserListsService {
       throw new NotFoundException();
     }
 
-    const userList = await this.findOneUserListByWorkspaceIdForUserIdUnguarded(id, userListId);
+    const userList = await this.findOneUserListByWorkspaceIdListIdUnguarded(id, userListId);
 
     return this.userListService.findListContributorsHighlightedRepos(pageOptionsDto, userList.id);
   }
@@ -228,7 +228,7 @@ export class WorkspaceUserListsService {
       throw new UnauthorizedException();
     }
 
-    const userList = await this.findOneUserListByWorkspaceIdForUserIdUnguarded(id, userListId);
+    const userList = await this.findOneUserListByWorkspaceIdListIdUnguarded(id, userListId);
 
     const contributors = dto.contributors.map(async (contributor) =>
       this.userListService.addUserListContributor(userList.id, contributor.id, contributor.login)
@@ -307,13 +307,13 @@ export class WorkspaceUserListsService {
       throw new UnauthorizedException();
     }
 
-    const userList = await this.findOneUserListByWorkspaceIdForUserIdUnguarded(id, userListId);
+    const userList = await this.findOneUserListByWorkspaceIdListIdUnguarded(id, userListId);
 
     await this.userListService.updateUserList(userList.id, {
       name: dto.name,
     });
 
-    return this.userListService.findOneById(userList.id, userId);
+    return this.findOneUserListByWorkspaceIdListIdUnguarded(id, userListId);
   }
 
   async deleteWorkspaceUserList(id: string, userListId: string, userId: number) {
@@ -329,7 +329,7 @@ export class WorkspaceUserListsService {
       throw new UnauthorizedException();
     }
 
-    const userList = await this.findOneUserListByWorkspaceIdForUserIdUnguarded(id, userListId);
+    const userList = await this.findOneUserListByWorkspaceIdListIdUnguarded(id, userListId);
 
     await this.userListService.deleteUserList(userList.id);
   }
@@ -352,7 +352,7 @@ export class WorkspaceUserListsService {
       throw new UnauthorizedException();
     }
 
-    const userList = await this.findOneUserListByWorkspaceIdForUserIdUnguarded(id, userListId);
+    const userList = await this.findOneUserListByWorkspaceIdListIdUnguarded(id, userListId);
 
     await this.userListService.deleteUserListContributor(userList.id, userListContributorId);
   }


### PR DESCRIPTION
## Description

Followup to #637:

- Refactors `findOneUserListByWorkspaceIdForUserIdUnguarded` function name for workspace-list-service to reflect using list ID and not the user id to find workspace contrib lists

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [x] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

Followup to #635 and #636

## Mobile & Desktop Screenshots/Recordings

## Steps to QA

Able to patch contrib list:

![Screenshot 2024-03-11 at 10 35 54 AM](https://github.com/open-sauced/api/assets/23109390/64c032f0-f08f-472f-9a13-f352a3ba727c)

## Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 docs.opensauced.pizza
- [ ] 🍕 dev.to/opensauced
- [ ] 📕 storybook
- [ ] 🙅 no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
