### PR TITLE
fix: Make "is_public" in insights dto optional

### DIFF
--- a/src/insight/dtos/create-insight.dto.ts
+++ b/src/insight/dtos/create-insight.dto.ts
@@ -1,6 +1,6 @@
-import { ApiProperty } from "@nestjs/swagger";
+import { ApiProperty, ApiPropertyOptional } from "@nestjs/swagger";
 import { Type } from "class-transformer";
-import { IsArray, IsBoolean, IsString } from "class-validator";
+import { IsArray, IsBoolean, IsOptional, IsString } from "class-validator";
 
 import { RepoInfo } from "../../repo/dtos/repo-info.dto";
 
@@ -13,13 +13,14 @@ export class CreateInsightDto {
   @IsString()
   name: string;
 
-  @ApiProperty({
+  @ApiPropertyOptional({
     description: "Insight Page Visibility",
     type: Boolean,
-    example: false,
+    example: true,
   })
+  @IsOptional()
   @IsBoolean()
-  is_public: boolean;
+  is_public?: boolean = true;
 
   @ApiProperty({
     description: "An array of repository information objects",

--- a/src/user-lists/dtos/create-user-list.dto.ts
+++ b/src/user-lists/dtos/create-user-list.dto.ts
@@ -1,6 +1,6 @@
-import { ApiProperty } from "@nestjs/swagger";
+import { ApiProperty, ApiPropertyOptional } from "@nestjs/swagger";
 import { Type } from "class-transformer";
-import { IsArray, IsBoolean, IsString } from "class-validator";
+import { IsArray, IsBoolean, IsOptional, IsString } from "class-validator";
 
 export class Contributor {
   id: number;
@@ -16,13 +16,14 @@ export class CreateUserListDto {
   @IsString()
   name: string;
 
-  @ApiProperty({
+  @ApiPropertyOptional({
     description: "List Visibility",
     type: Boolean,
-    example: false,
+    example: true,
   })
   @IsBoolean()
-  is_public: boolean;
+  @IsOptional()
+  is_public?: boolean = true;
 
   @ApiProperty({
     description: "An array of contributor objects",


### PR DESCRIPTION
Since insight assets access control was hoisted up to the workspace level, we  don't need API consumers to provide a "is_private" key.

Leaving the option in place since we may need that in the future and there's alot to unwind with how insights work and their "membership"

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

Closes: https://github.com/open-sauced/api/issues/686
Related to: https://github.com/open-sauced/app/issues/3049#issuecomment-2025220342

## Mobile & Desktop Screenshots/Recordings

## Steps to QA

Able to patch a repo insight without that DTO key:

<img width="473" alt="Screenshot 2024-03-28 at 3 43 14 PM" src="https://github.com/open-sauced/api/assets/23109390/d7531f50-8521-41fc-9fa9-a1f8ae54a9ac">

Able to patch a user list without that DTO key:

<img width="425" alt="Screenshot 2024-03-28 at 3 41 52 PM" src="https://github.com/open-sauced/api/assets/23109390/3faea547-9c6f-495a-a048-7e67672da41d">


## Tier (staff will fill in)

- [ ] Tier 1
- [ ] Tier 2
- [ ] Tier 3
- [x] Tier 4

## [optional] Are there any post-deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExc2x5aHJ5cnN6Mnlzb3A0eHJoajhsbDduZDZ4YnR3cGhhMnJqbjlwaiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/5t1YusAYxmRn474Sid/giphy.gif)