### PR TITLE
feat: Implements the lottery factor

### DIFF
--- a/src/repo/common/lotto.spec.ts
+++ b/src/repo/common/lotto.spec.ts
@@ -1,0 +1,74 @@
+import { DbContributorCounts } from "../../timescale/entities/contributor_counts.entity";
+import { LotteryFactorEnum } from "../entities/lotto.entity";
+import { calculateLottoFactor } from "./lotto";
+
+describe("calculateLottoFactor", () => {
+  it("should assign VERY_HIGH risk if one contributor makes over 50% of commits", () => {
+    const contribCounts: DbContributorCounts[] = [
+      { contributor: "jpmcb", count: 600, percent_of_total: 0, lotto_factor: "" },
+      { contributor: "nickytonline", count: 400, percent_of_total: 0, lotto_factor: "" },
+    ];
+    const result = calculateLottoFactor(contribCounts);
+
+    expect(result.all_lotto_factor).toEqual(LotteryFactorEnum.VERY_HIGH);
+    expect(result.all_contribs[0].lotto_factor).toEqual(LotteryFactorEnum.VERY_HIGH);
+  });
+
+  it("should assign HIGH risk if two contributors make over 50% of commits", () => {
+    const contribCounts: DbContributorCounts[] = [
+      { contributor: "jpmcb", count: 300, percent_of_total: 0, lotto_factor: "" },
+      { contributor: "nickytonline", count: 300, percent_of_total: 0, lotto_factor: "" },
+      { contributor: "bdougie", count: 400, percent_of_total: 0, lotto_factor: "" },
+    ];
+    const result = calculateLottoFactor(contribCounts);
+
+    expect(result.all_lotto_factor).toEqual(LotteryFactorEnum.HIGH);
+  });
+
+  it("should assign MODERATE risk if 3 to 5 contributors make over 50% of commits", () => {
+    const contribCounts: DbContributorCounts[] = [
+      { contributor: "jpmcb", count: 200, percent_of_total: 0, lotto_factor: "" },
+      { contributor: "nickytonline", count: 200, percent_of_total: 0, lotto_factor: "" },
+      { contributor: "bdougie", count: 200, percent_of_total: 0, lotto_factor: "" },
+      { contributor: "zeucapua", count: 200, percent_of_total: 0, lotto_factor: "" },
+      { contributor: "brandonroberts", count: 200, percent_of_total: 0, lotto_factor: "" },
+    ];
+    const result = calculateLottoFactor(contribCounts);
+
+    expect(result.all_lotto_factor).toEqual(LotteryFactorEnum.MODERATE);
+  });
+
+  it("should assign LOW risk if over 5 contributors make over 50% of commits", () => {
+    const contribCounts: DbContributorCounts[] = [
+      { contributor: "jpmcb", count: 100, percent_of_total: 0, lotto_factor: "" },
+      { contributor: "nickytonline", count: 100, percent_of_total: 0, lotto_factor: "" },
+      { contributor: "bdougie", count: 100, percent_of_total: 0, lotto_factor: "" },
+      { contributor: "zeucapua", count: 100, percent_of_total: 0, lotto_factor: "" },
+      { contributor: "brandonroberts", count: 100, percent_of_total: 0, lotto_factor: "" },
+      { contributor: "bekahHW", count: 100, percent_of_total: 0, lotto_factor: "" },
+      { contributor: "takanome-dev", count: 100, percent_of_total: 0, lotto_factor: "" },
+      { contributor: "isabensusan", count: 100, percent_of_total: 0, lotto_factor: "" },
+      { contributor: "OgDev-01", count: 100, percent_of_total: 0, lotto_factor: "" },
+      { contributor: "manipanditk", count: 100, percent_of_total: 0, lotto_factor: "" },
+    ];
+    const result = calculateLottoFactor(contribCounts);
+
+    expect(result.all_lotto_factor).toEqual(LotteryFactorEnum.LOW);
+  });
+
+  it("should correctly calculate individual lotto factors based on contribution percentages", () => {
+    const contribCounts: DbContributorCounts[] = [
+      { contributor: "jpmcb", count: 49, percent_of_total: 0, lotto_factor: "" },
+      { contributor: "nickytonline", count: 150, percent_of_total: 0, lotto_factor: "" },
+      { contributor: "bdougie", count: 300, percent_of_total: 0, lotto_factor: "" },
+      { contributor: "zeucapua", count: 501, percent_of_total: 0, lotto_factor: "" },
+    ];
+
+    const result = calculateLottoFactor(contribCounts);
+
+    expect(result.all_contribs[3].lotto_factor).toEqual(LotteryFactorEnum.LOW);
+    expect(result.all_contribs[2].lotto_factor).toEqual(LotteryFactorEnum.MODERATE);
+    expect(result.all_contribs[1].lotto_factor).toEqual(LotteryFactorEnum.HIGH);
+    expect(result.all_contribs[0].lotto_factor).toEqual(LotteryFactorEnum.VERY_HIGH);
+  });
+});

--- a/src/repo/common/lotto.ts
+++ b/src/repo/common/lotto.ts
@@ -1,0 +1,115 @@
+import { DbContributorCounts } from "../../timescale/entities/contributor_counts.entity";
+import { DbLotteryFactor, LotteryFactorEnum } from "../entities/lotto.entity";
+
+/*
+ * the following function can be used on a list of contributor counts,
+ * which denote the number of contributions someone has made in a given time-frame,
+ * in order to calculate the lottery factor over that time range for both the
+ * individual and the broader set of contributions.
+ *
+ * we define the lottery factor as:
+ *   > the minimum number of team members that have to suddenly disappear from a
+ *   > project (they won the lottery!) before the project stalls due to lack of
+ *   > knowledgeable or competent personnel.
+ *
+ * One way to look at this algorithm is via "equine" mathematics:
+ *   > the lowest number of committers who's total contribution constitutes the
+ *   > majority of the codebase
+ *   > Source: https://ke4qqq.wordpress.com/2015/02/08/pony-factor-math/
+ * Many call this the "pony" factor and is an adopted metric in the Apache software foundation.
+ *
+ * It is calculated using the following algorithm:
+ *   - 1 contributor makes over 50% of commits: Very high risk
+ *   - 2 contributors make over 50% of commits: High risk
+ *   - 3 to 5 contributors make over 50% of commits: Moderate risk
+ *   - Over 5 contributors make over 50% of commits: Low risk
+ *
+ * And, on an individual level, it is calculated as:
+ *   - A contributor has over 50% of commits: Very high risk
+ *   - A contributor has between 25-50% of commits: High risk
+ *   - A contributor has between 10-25% of commits: Moderate risk
+ *   - A contributor has under 10% of commits: Low risk
+ */
+
+export function calculateLottoFactor(contribCounts: DbContributorCounts[]): DbLotteryFactor {
+  const result = new DbLotteryFactor();
+
+  // first, ensure the list is sorted by the contributor counts in descending order
+  contribCounts.sort((a, b) => b.count - a.count);
+
+  // get the total number of contributions in the timeframe window
+  const total = contribCounts.reduce((sum, contrib) => sum + contrib.count, 0);
+
+  /*
+   * calculate the index at which 50% of commits are being made by top contributors.
+   * this is done by iterating the list and denoting the index up until the
+   * running total of contributions is > 50 % of contributions.
+   */
+
+  let cumulativeCount = 0;
+  let i = 0;
+
+  // eslint-disable-next-line no-loops/no-loops
+  while (cumulativeCount < total * 0.5 && i < contribCounts.length) {
+    cumulativeCount += contribCounts[i].count;
+    i++;
+  }
+
+  let allLottoFactor = LotteryFactorEnum.LOW;
+
+  // a sole contributor has over 50% of commits: Very high risk
+  if (i >= 1) {
+    allLottoFactor = LotteryFactorEnum.VERY_HIGH;
+  }
+
+  // two contributors have combined over 50% of contributions: High risk
+  if (i >= 2) {
+    allLottoFactor = LotteryFactorEnum.HIGH;
+  }
+
+  // 3-5 contributors combined have over 50% of contributions: Moderate risk
+  if (i >= 3) {
+    allLottoFactor = LotteryFactorEnum.MODERATE;
+  }
+
+  // over 5 contributors combined have over 50% of contributions: Low risk
+  if (i >= 5) {
+    allLottoFactor = LotteryFactorEnum.LOW;
+  }
+
+  /*
+   * calculates the risk factor for individuals when compared to the total.
+   * Any one person may have a large number of contributions which can be helpful
+   * in understanding where individuals lie within a lottery factor index
+   */
+
+  contribCounts.map((contrib) => {
+    contrib.percent_of_total = contrib.count / total;
+
+    // the contributor has 10% or less of total contributions: Low risk
+    if (contrib.percent_of_total <= 0.1) {
+      contrib.lotto_factor = LotteryFactorEnum.LOW;
+      return;
+    }
+
+    // the contributor has between 10-25% of total contributions: Moderate risk
+    if (contrib.percent_of_total <= 0.25) {
+      contrib.lotto_factor = LotteryFactorEnum.MODERATE;
+      return;
+    }
+
+    // the contributor has between 25-50% of total contributions: High risk
+    if (contrib.percent_of_total <= 0.5) {
+      contrib.lotto_factor = LotteryFactorEnum.HIGH;
+      return;
+    }
+
+    // the contributor has over 50% of total contributions: Very high risk
+    contrib.lotto_factor = LotteryFactorEnum.VERY_HIGH;
+  });
+
+  result.all_contribs = contribCounts;
+  result.all_lotto_factor = allLottoFactor;
+
+  return result;
+}

--- a/src/repo/dtos/repo-search-options.dto.ts
+++ b/src/repo/dtos/repo-search-options.dto.ts
@@ -1,5 +1,6 @@
-import { ApiPropertyOptional } from "@nestjs/swagger";
-import { IsEnum, IsOptional, IsString } from "class-validator";
+import { ApiProperty, ApiPropertyOptional } from "@nestjs/swagger";
+import { IsEnum, IsIn, IsInt, IsOptional, IsString } from "class-validator";
+import { Type } from "class-transformer";
 import { InsightFilterFieldsEnum } from "../../insight/dtos/insight-options.dto";
 
 import { RepoPageOptionsDto } from "./repo-page-options.dto";
@@ -30,4 +31,32 @@ export class RepoSearchOptionsDto extends RepoPageOptionsDto {
   @IsString()
   @IsOptional()
   readonly repoIds?: string;
+}
+
+export class RepoRangeOptionsDto {
+  @ApiProperty()
+  @IsString()
+  readonly repos: string;
+
+  @ApiPropertyOptional({
+    description: "Range in days",
+    default: 30,
+    type: "integer",
+  })
+  @Type(() => Number)
+  @IsIn([7, 30, 90])
+  @IsInt()
+  @IsOptional()
+  readonly range?: number = 30;
+
+  @ApiPropertyOptional({
+    description: "Number of days in the past to start range block",
+    default: 0,
+    type: "integer",
+  })
+  @Type(() => Number)
+  @IsIn([0, 7, 30, 90])
+  @IsInt()
+  @IsOptional()
+  readonly prevDaysStartDate?: number = 0;
 }

--- a/src/repo/dtos/repo-search-options.dto.ts
+++ b/src/repo/dtos/repo-search-options.dto.ts
@@ -58,5 +58,5 @@ export class RepoRangeOptionsDto {
   @IsIn([0, 7, 30, 90])
   @IsInt()
   @IsOptional()
-  readonly prevDaysStartDate?: number = 0;
+  readonly prev_days_start_date?: number = 0;
 }

--- a/src/repo/entities/lotto.entity.ts
+++ b/src/repo/entities/lotto.entity.ts
@@ -1,0 +1,39 @@
+import { ApiModelProperty } from "@nestjs/swagger/dist/decorators/api-model-property.decorator";
+import { Type } from "class-transformer";
+import { IsArray, IsEnum } from "class-validator";
+import { Entity, Column } from "typeorm";
+import { DbContributorCounts } from "../../timescale/entities/contributor_counts.entity";
+
+export enum LotteryFactorEnum {
+  LOW = "low",
+  MODERATE = "moderate",
+  HIGH = "high",
+  VERY_HIGH = "very-high",
+}
+
+@Entity({ name: "pull_request_github_events" })
+export class DbLotteryFactor {
+  @ApiModelProperty({
+    description: "",
+    isArray: true,
+    example: [],
+  })
+  @Column({
+    select: false,
+    insert: false,
+  })
+  @IsArray()
+  @Type(() => DbContributorCounts)
+  public all_contribs: DbContributorCounts[];
+
+  @ApiModelProperty({
+    description: "Lottery factor risk level for entire repo: one of low, moderate, high, very-high",
+    example: "moderate",
+  })
+  @Column({
+    select: false,
+    insert: false,
+  })
+  @IsEnum(LotteryFactorEnum)
+  public all_lotto_factor: LotteryFactorEnum;
+}

--- a/src/repo/repo.controller.ts
+++ b/src/repo/repo.controller.ts
@@ -10,9 +10,10 @@ import { RepoDevstatsService } from "../timescale/repo-devstats.service";
 import { DbRepo } from "./entities/repo.entity";
 import { RepoService } from "./repo.service";
 import { RepoPageOptionsDto } from "./dtos/repo-page-options.dto";
-import { RepoSearchOptionsDto } from "./dtos/repo-search-options.dto";
+import { RepoRangeOptionsDto, RepoSearchOptionsDto } from "./dtos/repo-search-options.dto";
 import { DbRepoContributor } from "./entities/repo_contributors.entity";
 import { RepoReleaseDto } from "./dtos/repo-release.dto";
+import { DbLotteryFactor } from "./entities/lotto.entity";
 
 @Controller("repos")
 @ApiTags("Repository service")
@@ -46,6 +47,18 @@ export class RepoController {
   @Header("Cache-Control", "public, max-age=600")
   async findOneByOwnerAndRepo(@Param("owner") owner: string, @Param("repo") repo: string): Promise<DbRepo> {
     return this.repoService.tryFindRepoOrMakeStub({ repoOwner: owner, repoName: repo });
+  }
+
+  @Get("/lotto")
+  @ApiOperation({
+    operationId: "findLottoFactorByOwnerAndRepo",
+    summary: "Calcultes the lotto factor for a repo by :owner and :repo",
+  })
+  @ApiOkResponse({ type: DbLotteryFactor })
+  @ApiNotFoundResponse({ description: "Repository not found" })
+  @Header("Cache-Control", "public, max-age=600")
+  async findLottoFactorByOwnerAndRepo(@Query() pageOptionsDto: RepoRangeOptionsDto): Promise<DbLotteryFactor> {
+    return this.repoService.findLottoFactor(pageOptionsDto);
   }
 
   @Get("/:owner/:repo/contributors")

--- a/src/repo/repo.service.ts
+++ b/src/repo/repo.service.ts
@@ -223,9 +223,13 @@ export class RepoService {
   }
 
   async findLottoFactor(pageOptionsDto: RepoRangeOptionsDto): Promise<DbLotteryFactor> {
+    if (pageOptionsDto.repos.length === 0) {
+      return new DbLotteryFactor();
+    }
+
     const contribCounts = await this.pullRequestGithubEventsService.findAllPrAuthorCounts({
       range: pageOptionsDto.range ?? 30,
-      prevDaysStartDate: pageOptionsDto.prevDaysStartDate ?? 0,
+      prevDaysStartDate: pageOptionsDto.prev_days_start_date ?? 0,
       repoNames: pageOptionsDto.repos.split(","),
     });
 

--- a/src/timescale/entities/contributor_counts.entity.ts
+++ b/src/timescale/entities/contributor_counts.entity.ts
@@ -1,0 +1,6 @@
+export class DbContributorCounts {
+  public contributor: string;
+  public count: number;
+  public percent_of_total: number;
+  public lotto_factor: string;
+}


### PR DESCRIPTION
## Description

Implements the lottery factor: see inline comments in the `src/repo/common/lotto.ts` for implementation details on the algorithm implemented.

Creates the `v2/repo/lotto` endpoint that can be queried to get lottery factor details. These details are in the form:

```json5
{
  "all_contribs": [
    {
      "contributor": "contributor-login",  // name of the contributor
      "count": 99,                         // the number of contributions in range
      "percent_of_total": 0.99,            // the percentage of total contributions
      "lotto_factor": "very-high"          // their individual lotto factor
    },
    
    // etc. etc. - rest of the contributors within time range for given repos
    // and their lotto factor

    {
      "contributor": "other-contributor-login",
      "count": 1,
      "percent_of_total": 0.01,
      "lotto_factor": "low"
    }
  ],

  // The lotto factor across the entire time range for all contributors
  // this is slightly different than the individual level and is designed to
  // capture lotto factor anomalies among small groups of individuals
  // (2 or 3 people making the majority of the contributions)
  "all_lotto_factor": "high"
}
```

## Related Tickets & Documents

Closes: https://github.com/open-sauced/api/issues/667

## Mobile & Desktop Screenshots/Recordings

## Steps to QA

Some example payloads:

#### `open-sauced/api`

```json5
{
  "all_contribs": [
    {
      "contributor": "jpmcb",
      "count": 121,
      "percent_of_total": 0.852112676056338,
      "lotto_factor": "very-high"
    },
    {
      "contributor": "brandonroberts",
      "count": 17,
      "percent_of_total": 0.11971830985915492,
      "lotto_factor": "moderate"
    },
    {
      "contributor": "isabensusan",
      "count": 1,
      "percent_of_total": 0.007042253521126761,
      "lotto_factor": "low"
    },
    {
      "contributor": "jimbobbennett",
      "count": 1,
      "percent_of_total": 0.007042253521126761,
      "lotto_factor": "low"
    },
    {
      "contributor": "nickytonline",
      "count": 1,
      "percent_of_total": 0.007042253521126761,
      "lotto_factor": "low"
    },
    {
      "contributor": "OgDev-01",
      "count": 1,
      "percent_of_total": 0.007042253521126761,
      "lotto_factor": "low"
    }
  ],
  "all_lotto_factor": "very-high"
}
```

#### `open-sauced/app`

```json5
{
  "all_contribs": [
    {
      "contributor": "brandonroberts",
      "count": 41,
      "percent_of_total": 0.3360655737704918,
      "lotto_factor": "high"
    },
    {
      "contributor": "nickytonline",
      "count": 37,
      "percent_of_total": 0.30327868852459017,
      "lotto_factor": "high"
    },
    {
      "contributor": "zeucapua",
      "count": 27,
      "percent_of_total": 0.22131147540983606,
      "lotto_factor": "moderate"
    },
    {
      "contributor": "jpmcb",
      "count": 4,
      "percent_of_total": 0.03278688524590164,
      "lotto_factor": "low"
    },
    {
      "contributor": "takanome-dev",
      "count": 3,
      "percent_of_total": 0.02459016393442623,
      "lotto_factor": "low"
    },
    {
      "contributor": "malezjaa",
      "count": 2,
      "percent_of_total": 0.01639344262295082,
      "lotto_factor": "low"
    },
    {
      "contributor": "FatumaA",
      "count": 2,
      "percent_of_total": 0.01639344262295082,
      "lotto_factor": "low"
    },
    {
      "contributor": "bdougie",
      "count": 1,
      "percent_of_total": 0.00819672131147541,
      "lotto_factor": "low"
    },
    {
      "contributor": "BekahHW",
      "count": 1,
      "percent_of_total": 0.00819672131147541,
      "lotto_factor": "low"
    },
    {
      "contributor": "G-nizam-A",
      "count": 1,
      "percent_of_total": 0.00819672131147541,
      "lotto_factor": "low"
    },
    {
      "contributor": "arvindpndit",
      "count": 1,
      "percent_of_total": 0.00819672131147541,
      "lotto_factor": "low"
    },
    {
      "contributor": "Re1nGer",
      "count": 1,
      "percent_of_total": 0.00819672131147541,
      "lotto_factor": "low"
    },
    {
      "contributor": "isabensusan",
      "count": 1,
      "percent_of_total": 0.00819672131147541,
      "lotto_factor": "low"
    }
  ],
  "all_lotto_factor": "high"
}
```

#### `kubernetes/kubernetes`

```json5
{
  "all_contribs": [
    {
      "contributor": "carlory",
      "count": 18,
      "percent_of_total": 0.05750798722044728,
      "lotto_factor": "low"
    },
    {
      "contributor": "pohly",
      "count": 14,
      "percent_of_total": 0.04472843450479233,
      "lotto_factor": "low"
    },

    // etc. etc. many 1 contribution counts

    {
      "contributor": "zyjhtangtang",
      "count": 1,
      "percent_of_total": 0.003194888178913738,
      "lotto_factor": "low"
    }
  ],
  "all_lotto_factor": "low"
}
```

## Tier (staff will fill in)

- [ ] Tier 1
- [ ] Tier 2
- [ ] Tier 3
- [x] Tier 4

## [optional] Are there any post-deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExZ2w1NDBscXg0eHZmZWpibW1yb2Y1cGNqeHZhYW45bDY2dTA1bjU1MyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/H3SpUfkTQZXupCpdfv/giphy.gif)

<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
