### PR TITLE
fix: Corrects linting warnings (and bump builds)

### DIFF
--- a/src/insight/user-insight.controller.ts
+++ b/src/insight/user-insight.controller.ts
@@ -1,5 +1,4 @@
 import {
-  BadRequestException,
   Body,
   Controller,
   Get,
@@ -76,10 +75,6 @@ export class UserInsightsController {
   @ApiBadRequestResponse({ description: "Invalid request" })
   @ApiBody({ type: CreateInsightDto })
   async addInsightForUser(@Body() createInsightDto: CreateInsightDto, @UserId() userId: number): Promise<DbInsight> {
-    if (!createInsightDto.name || !Array.isArray(createInsightDto.repos)) {
-      throw new BadRequestException();
-    }
-
     // use an empty workspace ID to force this being added to the users personal workspace
     const newInsight = await this.insightsService.addInsight(userId, "", {
       name: createInsightDto.name,
@@ -128,7 +123,7 @@ export class UserInsightsController {
 
     try {
       // current set of insight repos
-      const currentRepos = insight.repos?.filter((insightRepo) => !insightRepo.deleted_at) || [];
+      const currentRepos = insight.repos?.filter((insightRepo) => !insightRepo.deleted_at) ?? [];
 
       // remove deleted repos
       const reposToRemove = currentRepos.filter(

--- a/src/workspace/workspace-insights.service.ts
+++ b/src/workspace/workspace-insights.service.ts
@@ -209,7 +209,7 @@ export class WorkspaceInsightsService {
 
     try {
       // current set of insight repos
-      const currentRepos = insight.repos?.filter((insightRepo) => !insightRepo.deleted_at) || [];
+      const currentRepos = insight.repos?.filter((insightRepo) => !insightRepo.deleted_at) ?? [];
 
       // remove deleted repos
       const reposToRemove = currentRepos.filter(

--- a/src/workspace/workspace.service.ts
+++ b/src/workspace/workspace.service.ts
@@ -4,7 +4,6 @@ import { InjectRepository } from "@nestjs/typeorm";
 
 import { PageOptionsDto } from "../common/dtos/page-options.dto";
 import { PageDto } from "../common/dtos/page.dto";
-import { PagerService } from "../common/services/pager.service";
 import { RepoService } from "../repo/repo.service";
 import { DbUser } from "../user/user.entity";
 import { UserService } from "../user/services/user.service";
@@ -28,7 +27,6 @@ export class WorkspaceService {
     private workspaceContributorRepository: Repository<DbWorkspaceContributor>,
     @InjectRepository(DbUser, "ApiConnection")
     private userRepository: Repository<DbUser>,
-    private pagerService: PagerService,
     private repoService: RepoService,
     private userService: UserService
   ) {}
@@ -106,7 +104,7 @@ export class WorkspaceService {
 
     const workspaceId = await workspaceIdQb.getRawOne<{ personal_workspace_id: string }>();
 
-    if (!workspaceId || !workspaceId.personal_workspace_id) {
+    if (!workspaceId?.personal_workspace_id) {
       throw new NotFoundException();
     }
 


### PR DESCRIPTION
## Description

Small PR to bump builds:
- corrects usage of `||` operator in favor of `??`
- Removes unused pager service in workspaces
- Removes unnecessary check for required `name` and `repos` dto elements

## Related Tickets & Documents

N/a - bumps builds after failure in last release run

## Mobile & Desktop Screenshots/Recordings

## Steps to QA

## Tier (staff will fill in)

- [ ] Tier 1
- [ ] Tier 2
- [ ] Tier 3
- [x] Tier 4

## [optional] Are there any post-deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?