### PR TITLE
fix: Found repos for lottery factor have full_names correctly lower-cased

### DIFF
--- a/src/repo/repo.service.ts
+++ b/src/repo/repo.service.ts
@@ -302,7 +302,7 @@ export class RepoService {
     });
 
     const reposResolved = await Promise.all(repoInfos);
-    const resolvedRepoNames = reposResolved.map((repo) => repo.full_name);
+    const resolvedRepoNames = reposResolved.map((repo) => repo.full_name.toLowerCase());
 
     // finding the oldest 'created_at' date for the given repos
     const endOfGracePeriod = reposResolved.reduce(


### PR DESCRIPTION
## Description

Fixes where repos with case sensitive names (from the `full_name` field in our metadata database) wasn't getting lower-cased correctly by the lottery factor calling function.

## Related Tickets & Documents

Followup to https://github.com/open-sauced/api/pull/804

Previously for `microsoft/TypeScript`:

```json5
{
  "all_contribs": [],
  "all_lotto_factor": "very-high",
  "grace_period_end": "2014-07-17T15:28:39.000Z"
}
```

Now:

```json5
{
  "all_contribs": [
    {
      "contributor": "jakebailey",
      "count": 19,
      "percent_of_total": 0.17592592592592593,
      "lotto_factor": "moderate"
    },

    // ... etc.

  ],
  "all_lotto_factor": "moderate",
  "grace_period_end": "2014-07-17T21:28:39.000Z"
}
```

## Steps to QA

Call the /v2/repos/lotto endpoint with a "case-sensitive" repo name like `microsoft/TypeScript`.

## Tier (staff will fill in)

- [ ] Tier 1
- [ ] Tier 2
- [ ] Tier 3
- [x] Tier 4

## [optional] What gif best describes this PR or how it makes you feel?

![](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExaWVsemJtNDN0MjlrNGZ5cTd4dG00cXRqZ3NzZW5nd2ZodW5vZHYyaSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/EUnVjFsXUSWuZM8Tqi/giphy.gif)